### PR TITLE
General performance optimization and fixes for HashTable

### DIFF
--- a/headers/hashtable.h
+++ b/headers/hashtable.h
@@ -13,14 +13,12 @@ struct HashTableField {
   string_t name;
   void *value;
   enum TellyTypes type;
-  struct HashTableField *next;
   uint64_t hash;
 };
 
 struct HashTableSize {
-  uint32_t allocated; // total allocated size
-  uint32_t filled; // filled allocated block count
-  uint32_t all; // contains next values
+  uint32_t capacity; // total allocated size
+  uint32_t used; // filled allocated block count
 };
 
 struct HashTable {

--- a/headers/hashtable.h
+++ b/headers/hashtable.h
@@ -33,5 +33,5 @@ void free_hashtable(struct HashTable *table);
 
 void free_htfield(struct HashTableField *field);
 
-void add_field_to_hashtable(struct HashTable *table, const string_t name, void *value, const enum TellyTypes type);
+void set_field_of_hashtable(struct HashTable *table, const string_t name, void *value, const enum TellyTypes type);
 bool del_field_to_hashtable(struct HashTable *table, const string_t name);

--- a/headers/resp.h
+++ b/headers/resp.h
@@ -17,17 +17,25 @@
 
 #define RESP_BUF_SIZE 4096
 
-#define CREATE_RESP_INTEGER_VARIABLED(buf, value, nbytes) \
-  *buf = ':'; \
-  nbytes = ltoa(value, buf + 1); \
-  *(buf + nbytes + 1) = '\r'; \
-  *(buf + nbytes + 2) = '\n';
-
-#define CREATE_RESP_INTEGER(buf, value) \
-  *buf = ':'; \
-  const int __nbytes = ltoa(value, buf + 1); \
-  *(buf + __nbytes + 1) = '\r'; \
+static inline int create_resp_integer(char *buf, uint64_t value) {
+  *(buf) = ':';
+  const uint64_t __nbytes = ltoa(value, buf + 1);
+  *(buf + __nbytes + 1) = '\r';
   *(buf + __nbytes + 2) = '\n';
+  return (__nbytes + 3);
+}
+
+static inline uint64_t create_resp_string(char *buf, string_t string) {
+  *(buf) = '$';
+  const uint64_t __nbytes = ltoa(string.len, buf + 1);
+  *(buf + __nbytes + 1) = '\r';
+  *(buf + __nbytes + 2) = '\n';
+
+  memcpy(buf + __nbytes + 2, string.value, string.len);
+  *(buf + __nbytes + string.len + 2) = '\r';
+  *(buf + __nbytes + string.len + 3) = '\n';
+  return (__nbytes + string.len + 4);
+}
 
 typedef struct CommandData {
   string_t name;

--- a/headers/resp.h
+++ b/headers/resp.h
@@ -17,6 +17,18 @@
 
 #define RESP_BUF_SIZE 4096
 
+#define CREATE_RESP_INTEGER_VARIABLED(buf, value, nbytes) \
+  *buf = ':'; \
+  nbytes = ltoa(value, buf + 1); \
+  *(buf + nbytes + 1) = '\r'; \
+  *(buf + nbytes + 2) = '\n';
+
+#define CREATE_RESP_INTEGER(buf, value) \
+  *buf = ':'; \
+  const int __nbytes = ltoa(value, buf + 1); \
+  *(buf + __nbytes + 1) = '\r'; \
+  *(buf + __nbytes + 2) = '\n';
+
 typedef struct CommandData {
   string_t name;
 

--- a/headers/utils.h
+++ b/headers/utils.h
@@ -46,6 +46,7 @@ void memcpy_aligned(void *restrict dest, const void *restrict src, size_t n);
 
 bool is_integer(const char *value);
 void number_pad(char *res, const uint32_t value);
+int ltoa(const int64_t value, char *dst);
 
 void generate_random_string(char *dest, size_t length);
 void generate_date_string(char *text, const time_t value);

--- a/headers/utils.h
+++ b/headers/utils.h
@@ -46,7 +46,8 @@ void memcpy_aligned(void *restrict dest, const void *restrict src, size_t n);
 
 bool is_integer(const char *value);
 void number_pad(char *res, const uint32_t value);
-int ltoa(const int64_t value, char *dst);
+const int ltoa(const int64_t value, char *dst);
+const int get_digit_count(const uint64_t value);
 
 void generate_random_string(char *dest, size_t length);
 void generate_date_string(char *text, const time_t value);

--- a/src/commands/hashtable/hdel.c
+++ b/src/commands/hashtable/hdel.c
@@ -40,25 +40,27 @@ static void run(struct CommandEntry entry) {
       return;
     }
 
-    const uint32_t old_size = table->size.all;
+    const uint32_t old_size = table->size.used;
 
     for (uint32_t i = 1; i < entry.data->arg_count; ++i) {
       del_field_to_hashtable(table, entry.data->args[i]);
     }
 
-    if (table->size.all == 0) {
+    if (table->size.used == 0) {
       delete_data(entry.database, key);
     }
 
     char buf[14];
-    const size_t nbytes = sprintf(buf, ":%u\r\n", old_size - table->size.all);
+
+    // TODO: table may be deleted, but it tries to getting used size
+    const size_t nbytes = sprintf(buf, ":%u\r\n", old_size - table->size.used);
     _write(entry.client, buf, nbytes);
   } else {
     for (uint32_t i = 1; i < entry.data->arg_count; ++i) {
       del_field_to_hashtable(table, entry.data->args[i]);
     }
 
-    if (table->size.all == 0) {
+    if (table->size.used == 0) {
       delete_data(entry.database, key);
     }
   }

--- a/src/commands/hashtable/hdel.c
+++ b/src/commands/hashtable/hdel.c
@@ -27,7 +27,10 @@ static void run(struct CommandEntry entry) {
       return;
     }
   } else {
-    if (entry.client) _write(entry.client, ":0\r\n", 4);
+    if (entry.client) {
+      _write(entry.client, ":0\r\n", 4);
+    }
+
     return;
   }
 
@@ -43,7 +46,9 @@ static void run(struct CommandEntry entry) {
       del_field_to_hashtable(table, entry.data->args[i]);
     }
 
-    if (table->size.all == 0) delete_data(entry.database, key);
+    if (table->size.all == 0) {
+      delete_data(entry.database, key);
+    }
 
     char buf[14];
     const size_t nbytes = sprintf(buf, ":%u\r\n", old_size - table->size.all);

--- a/src/commands/hashtable/hdel.c
+++ b/src/commands/hashtable/hdel.c
@@ -46,14 +46,15 @@ static void run(struct CommandEntry entry) {
       del_field_to_hashtable(table, entry.data->args[i]);
     }
 
+    const uint32_t current_size = table->size.used;
+
     if (table->size.used == 0) {
       delete_data(entry.database, key);
     }
 
     char buf[14];
 
-    // TODO: table may be deleted, but it tries to getting used size
-    const size_t nbytes = sprintf(buf, ":%u\r\n", old_size - table->size.used);
+    const size_t nbytes = sprintf(buf, ":%u\r\n", old_size - current_size);
     _write(entry.client, buf, nbytes);
   } else {
     for (uint32_t i = 1; i < entry.data->arg_count; ++i) {

--- a/src/commands/hashtable/hget.c
+++ b/src/commands/hashtable/hget.c
@@ -22,8 +22,12 @@ static void run(struct CommandEntry entry) {
   }
 
   const struct HashTableField *field = get_field_from_hashtable(kv->value, entry.data->args[1]);
-  if (field) write_value(entry.client, field->value, field->type);
-  else WRITE_NULL_REPLY(entry.client);
+
+  if (field) {
+    write_value(entry.client, field->value, field->type);
+  } else {
+    WRITE_NULL_REPLY(entry.client);
+  }
 }
 
 const struct Command cmd_hget = {

--- a/src/commands/hashtable/hgetall.c
+++ b/src/commands/hashtable/hgetall.c
@@ -63,7 +63,7 @@ static const uint64_t calculate_length(const enum ProtocolVersion protover, cons
 
           switch (field->type) {
             case TELLY_NULL:
-              length += 7;
+              length += 3;
               break;
 
             case TELLY_NUM:
@@ -188,8 +188,8 @@ static void run(struct CommandEntry entry) {
 
           switch (field->type) {
             case TELLY_NULL:
-              memcpy(response + at, "+null\r\n", 7);
-              at += 7;
+              memcpy(response + at, "_\r\n", 3);
+              at += 3;
               break;
 
             case TELLY_NUM:

--- a/src/commands/hashtable/hkeys.c
+++ b/src/commands/hashtable/hkeys.c
@@ -5,16 +5,14 @@
 #include <stdint.h>
 
 static const uint64_t calculate_length(const struct HashTable *table) {
-  uint64_t length = (3 + get_digit_count(table->size.all)); // *number\r\n
+  uint64_t length = (3 + get_digit_count(table->size.used)); // *number\r\n
 
-  for (uint32_t i = 0; i < table->size.allocated; ++i) {
+  for (uint32_t i = 0; i < table->size.capacity; ++i) {
     const struct HashTableField *field = table->fields[i];
 
-    while (field) {
+    if (field) {
       const uint64_t line_length = (5 + get_digit_count(field->name.len) + field->name.len); // $number\r\nstring\r\n
       length += line_length;
-
-      field = field->next;
     }
   }
 
@@ -46,14 +44,14 @@ static void run(struct CommandEntry entry) {
   char *response = malloc(length);
 
   response[0] = '*';
-  uint64_t at = ltoa(table->size.all, response + 1) + 1;
+  uint64_t at = ltoa(table->size.used, response + 1) + 1;
   response[at++] = '\r';
   response[at++] = '\n';
 
-  for (uint32_t i = 0; i < table->size.allocated; ++i) {
+  for (uint32_t i = 0; i < table->size.capacity; ++i) {
     struct HashTableField *field = table->fields[i];
 
-    while (field) {
+    if (field) {
       response[at++] = '$';
       at += ltoa(field->name.len, response + at);
       response[at++] = '\r';
@@ -63,8 +61,6 @@ static void run(struct CommandEntry entry) {
       at += field->name.len;
       response[at++] = '\r';
       response[at++] = '\n';
-
-      field = field->next;
     }
   }
 

--- a/src/commands/hashtable/hkeys.c
+++ b/src/commands/hashtable/hkeys.c
@@ -5,7 +5,7 @@
 #include <stdint.h>
 
 static const uint64_t calculate_length(const struct HashTable *table) {
-  uint64_t length = 0;
+  uint64_t length = (3 + get_digit_count(table->size.all)); // *number\r\n
 
   for (uint32_t i = 0; i < table->size.allocated; ++i) {
     const struct HashTableField *field = table->fields[i];

--- a/src/commands/hashtable/hlen.c
+++ b/src/commands/hashtable/hlen.c
@@ -26,10 +26,9 @@ static void run(struct CommandEntry entry) {
   char buf[90];
   const size_t nbytes = sprintf(buf, (
     "*3\r\n"
-      "+Allocated: %u\r\n"
-      "+Filled: %u\r\n"
-      "+All (includes next count): %u\r\n"
-  ), table->size.allocated, table->size.filled, table->size.all);
+      "+Capacity: %u\r\n"
+      "+Used: %u\r\n"
+  ), table->size.capacity, table->size.used);
 
   _write(entry.client, buf, nbytes);
 }

--- a/src/commands/hashtable/hset.c
+++ b/src/commands/hashtable/hset.c
@@ -68,7 +68,7 @@ static void run(struct CommandEntry entry) {
 
   if (entry.client) {
     char buf[14];
-    const size_t buf_len = sprintf(buf, ":%u\r\n", fv_count);
+    const size_t buf_len = create_resp_integer(buf, fv_count);
 
     _write(entry.client, buf, buf_len);
   }

--- a/src/commands/hashtable/hset.c
+++ b/src/commands/hashtable/hset.c
@@ -48,21 +48,21 @@ static void run(struct CommandEntry entry) {
       long *value = malloc(sizeof(long));
       *value = number;
 
-      add_field_to_hashtable(table, name, value, TELLY_NUM);
+      set_field_of_hashtable(table, name, value, TELLY_NUM);
     } else if (is_true || streq(input_value, "false")) {
       bool *value = malloc(sizeof(bool));
       *value = is_true;
 
-      add_field_to_hashtable(table, name, value, TELLY_BOOL);
+      set_field_of_hashtable(table, name, value, TELLY_BOOL);
     } else if (streq(input_value, "null")) {
-      add_field_to_hashtable(table, name, NULL, TELLY_NULL);
+      set_field_of_hashtable(table, name, NULL, TELLY_NULL);
     } else {
       string_t *value = malloc(sizeof(string_t));
       value->len = input.len;
       value->value = malloc(value->len);
       memcpy(value->value, input_value, value->len);
 
-      add_field_to_hashtable(table, name, value, TELLY_STR);
+      set_field_of_hashtable(table, name, value, TELLY_STR);
     }
   }
 

--- a/src/commands/hashtable/hvals.c
+++ b/src/commands/hashtable/hvals.c
@@ -128,16 +128,13 @@ static void run(struct CommandEntry entry) {
               at += 7;
               break;
 
-            case TELLY_NUM: {
-              long number = *((long *) field->value);
-              at += create_resp_integer(response + at, number);
+            case TELLY_NUM:
+              at += create_resp_integer(response + at, *((long *) field->value));
               break;
-            }
 
-            case TELLY_STR: {
+            case TELLY_STR:
               at += create_resp_string(response + at, *((string_t *) field->value));
               break;
-            }
 
             case TELLY_BOOL: {
               if (*((bool *) field->value)) {

--- a/src/commands/hashtable/hvals.c
+++ b/src/commands/hashtable/hvals.c
@@ -55,7 +55,7 @@ static const uint64_t calculate_length(const enum ProtocolVersion protover, cons
         while (field) {
           switch (field->type) {
             case TELLY_NULL:
-              length += 7;
+              length += 3; // _\r\n
               break;
     
             case TELLY_NUM:
@@ -167,8 +167,8 @@ static void run(struct CommandEntry entry) {
         while (field) {
           switch (field->type) {
             case TELLY_NULL:
-              memcpy(response + at, "+null\r\n", 7);
-              at += 7;
+              memcpy(response + at, "_\r\n", 3);
+              at += 3;
               break;
 
             case TELLY_NUM:

--- a/src/database/file.c
+++ b/src/database/file.c
@@ -88,12 +88,11 @@ static off_t get_value_size(const enum TellyTypes type, void *value) {
       const struct HashTable *table = value;
       off_t length = 5;
 
-      for (uint32_t i = 0; i < table->size.allocated; ++i) {
+      for (uint32_t i = 0; i < table->size.capacity; ++i) {
         struct HashTableField *field = table->fields[i];
 
-        while (field) {
+        if (field) {
           length += (1 + get_value_size(TELLY_STR, &field->name) + get_value_size(field->type, field->value));
-          field = field->next;
         }
       }
 
@@ -171,13 +170,13 @@ static off_t generate_value(char **data, struct KVPair *kv) {
 
     case TELLY_HASHTABLE: {
       struct HashTable *table = kv->value;
-      memcpy(*data + len, &table->size.allocated, 4);
+      memcpy(*data + len, &table->size.capacity, 4);
       len += 4;
 
-      for (uint32_t i = 0; i < table->size.allocated; ++i) {
+      for (uint32_t i = 0; i < table->size.capacity; ++i) {
         struct HashTableField *field = table->fields[i];
 
-        while (field) {
+        if (field) {
           (*data)[len] = field->type;
           len += 1;
 
@@ -202,8 +201,6 @@ static off_t generate_value(char **data, struct KVPair *kv) {
             default:
               break;
           }
-
-          field = field->next;
         }
       }
 

--- a/src/database/get.c
+++ b/src/database/get.c
@@ -126,7 +126,7 @@ static size_t collect_kv(struct KVPair *kv, const int fd, char *block, const uin
               break;
           }
 
-          add_field_to_hashtable(table, name, fv_value, byte);
+          set_field_of_hashtable(table, name, fv_value, byte);
           free(name.value);
         }
       }

--- a/src/hashtable/fv.c
+++ b/src/hashtable/fv.c
@@ -8,7 +8,10 @@ void free_htfield(struct HashTableField *field) {
     free(string->value);
   }
 
-  if (field->type != TELLY_NULL) free(field->value);
+  if (field->type != TELLY_NULL) {
+    free(field->value);
+  }
+
   free(field->name.value);
   free(field);
 }

--- a/src/hashtable/hashtable.c
+++ b/src/hashtable/hashtable.c
@@ -7,63 +7,53 @@
 struct HashTable *create_hashtable(const uint32_t default_size) {
   struct HashTable *table = malloc(sizeof(struct HashTable));
   table->fields = calloc(default_size, sizeof(struct HashTableField *));
-  table->size.allocated = default_size;
-  table->size.all = 0;
-  table->size.filled = 0;
+  table->size.capacity = default_size;
+  table->size.used = 0;
 
   return table;
 }
 
 void resize_hashtable(struct HashTable *table, const uint32_t size) {
   struct HashTableField **data = calloc(size, sizeof(struct HashTableField *));
-  table->size.filled = 0;
 
-  for (uint32_t i = 0; i < table->size.allocated; ++i) {
+  for (uint32_t i = 0; i < table->size.capacity; ++i) {
     struct HashTableField *field = table->fields[i];
+    uint32_t index = field->hash % size;
 
-    while (field) {
-      const uint32_t index = field->hash % size;
-      struct HashTableField *next = field->next;
-
-      if (!data[index]) {
-        table->size.filled += 1;
-        field->next = NULL;
-      } else {
-        field->next = data[index];
-      }
-
-      data[index] = field;
-      field = next;
+    while (data[index]) {
+      index += 1;
     }
+
+    data[index] = table->fields[i];
   }
 
   free(table->fields);
-  table->size.allocated = size;
+  table->size.capacity = size;
   table->fields = data;
 }
 
 struct HashTableField *get_field_from_hashtable(struct HashTable *table, const string_t name) {
-  const uint32_t index = hash(name.value, name.len) % table->size.allocated;
-  struct HashTableField *field = table->fields[index];
+  uint32_t index = hash(name.value, name.len) % table->size.capacity;
+  struct HashTableField *field;
 
-  while (field && ((name.len != field->name.len) || (memcmp(field->name.value, name.value, name.len) != 0))) {
-    field = field->next;
-  }
+  do {
+    field = table->fields[index];
+    index += 1;
+
+    if (field && (name.len == field->name.len) && (memcmp(field->name.value, name.value, name.len) == 0)) {
+      return field;
+    }
+  } while (index != table->size.capacity);
 
   return field;
 }
 
 void free_hashtable(struct HashTable *table) {
-  const uint32_t allocated_size = table->size.allocated;
+  const uint32_t capacity = table->size.capacity;
 
-  for (uint32_t i = 0; i < allocated_size; ++i) {
+  for (uint32_t i = 0; i < capacity; ++i) {
     struct HashTableField *field = table->fields[i];
-
-    while (field) {
-      struct HashTableField *next = field->next;
-      free_htfield(field);
-      field = next;
-    }
+    free_htfield(field);
   }
 
   free(table->fields);

--- a/src/hashtable/hashtable.c
+++ b/src/hashtable/hashtable.c
@@ -46,7 +46,10 @@ struct HashTableField *get_field_from_hashtable(struct HashTable *table, const s
   const uint32_t index = hash(name.value, name.len) % table->size.allocated;
   struct HashTableField *field = table->fields[index];
 
-  while (field && ((name.len != field->name.len) || (memcmp(field->name.value, name.value, name.len) != 0))) field = field->next;
+  while (field && ((name.len != field->name.len) || (memcmp(field->name.value, name.value, name.len) != 0))) {
+    field = field->next;
+  }
+
   return field;
 }
 

--- a/src/hashtable/memory.c
+++ b/src/hashtable/memory.c
@@ -17,8 +17,11 @@ void add_field_to_hashtable(struct HashTable *table, const string_t name, void *
       if ((name.len == field->name.len) && (memcmp(field->name.value, name.value, name.len) == 0)) {
         found = true;
         break;
-      } else if (field->next) field = field->next;
-      else break;
+      } else if (field->next) {
+        field = field->next;
+      } else {
+        break;
+      }
     } while (field);
   } else {
     table->size.filled += 1;
@@ -28,7 +31,9 @@ void add_field_to_hashtable(struct HashTable *table, const string_t name, void *
     resize_hashtable(table, (table->size.allocated * HASHTABLE_GROW_FACTOR));
     index = hashed % table->size.allocated;
 
-    if (!table->fields[index]) table->size.filled += 1;
+    if (!table->fields[index]) {
+      table->size.filled += 1;
+    }
   }
 
   if (field) {
@@ -38,7 +43,9 @@ void add_field_to_hashtable(struct HashTable *table, const string_t name, void *
         free(string->value);
       }
 
-      if (field->type != TELLY_NULL) free(field->value);
+      if (field->type != TELLY_NULL) {
+        free(field->value);
+      }
 
       field->type = type;
       field->value = value;

--- a/src/hashtable/memory.c
+++ b/src/hashtable/memory.c
@@ -6,117 +6,58 @@
 #include <stdbool.h>
 
 void add_field_to_hashtable(struct HashTable *table, const string_t name, void *value, const enum TellyTypes type) {
+  if (table->size.used == table->size.capacity) {
+    resize_hashtable(table, (table->size.capacity * HASHTABLE_GROW_FACTOR));
+  }
+
   const uint64_t hashed = hash(name.value, name.len);
-  uint32_t index = hashed % table->size.allocated;
+  uint32_t index = hashed % table->size.capacity;
 
   struct HashTableField *field;
-  bool found = false;
 
-  if ((field = table->fields[index])) {
-    do {
-      if ((name.len == field->name.len) && (memcmp(field->name.value, name.value, name.len) == 0)) {
-        found = true;
-        break;
-      } else if (field->next) {
-        field = field->next;
-      } else {
-        break;
-      }
-    } while (field);
-  } else {
-    table->size.filled += 1;
-  }
-
-  if (table->size.allocated == table->size.filled) {
-    resize_hashtable(table, (table->size.allocated * HASHTABLE_GROW_FACTOR));
-    index = hashed % table->size.allocated;
-
-    if (!table->fields[index]) {
-      table->size.filled += 1;
+  while (field && index != table->size.capacity) {
+    if ((name.len != field->name.len) || (memcmp(field->name.value, name.value, name.len) != 0)) {
+      index += 1;
+      field = table->fields[index];
     }
   }
 
-  if (field) {
-    if (found) {
-      if (field->type == TELLY_STR) {
-        string_t *string = field->value;
-        free(string->value);
-      }
+  table->size.used += 1;
 
-      if (field->type != TELLY_NULL) {
-        free(field->value);
-      }
+  field = malloc(sizeof(struct HashTableField));
+  field->type = type;
+  field->value = value;
+  field->hash = hashed;
 
-      field->type = type;
-      field->value = value;
-    } else {
-      table->size.all += 1;
+  field->name.len = name.len;
+  field->name.value = malloc(name.len);
+  memcpy(field->name.value, name.value, name.len);
 
-      field->next = malloc(sizeof(struct HashTableField));
-      field = field->next;
-
-      field->type = type;
-      field->value = value;
-      field->hash = hashed;
-      field->next = NULL;
-
-      field->name.len = name.len;
-      field->name.value = malloc(name.len);
-      memcpy(field->name.value, name.value, name.len);
-    }
-  } else {
-    table->size.all += 1;
-
-    field = malloc(sizeof(struct HashTableField));
-    field->type = type;
-    field->value = value;
-    field->hash = hashed;
-    field->next = NULL;
-
-    field->name.len = name.len;
-    field->name.value = malloc(name.len);
-    memcpy(field->name.value, name.value, name.len);
-
-    table->fields[index] = field;
-  }
+  table->fields[index] = field;
 }
 
 bool del_field_to_hashtable(struct HashTable *table, const string_t name) {
   const uint64_t hashed = hash(name.value, name.len);
-  uint32_t index = hashed % table->size.allocated;
+  uint32_t index = hashed % table->size.capacity;
 
   struct HashTableField *field;
-  struct HashTableField *prev = NULL;
 
-  if ((field = table->fields[index])) {
-    do {
-      if ((name.len == field->name.len) && (memcmp(field->name.value, name.value, name.len) == 0)) {
-        // b is element will be deleted
-        if (prev) { // a b a or a a b
-          prev->next = field->next;
-        } else if (!field->next) { // b
-          table->size.filled -= 1;
-          table->fields[index] = NULL;
+  while (index != table->size.capacity && (field = table->fields[index])) {
+    if ((name.len == field->name.len) && (memcmp(field->name.value, name.value, name.len) == 0)) {
+      table->size.used -= 1;
+      table->fields[index] = NULL;
 
-          const uint32_t size = (table->size.allocated * HASHTABLE_SHRINK_FACTOR);
+      const uint32_t size = (table->size.capacity * HASHTABLE_SHRINK_FACTOR);
 
-          if (size == table->size.filled) {
-            resize_hashtable(table, size);
-          }
-        } else { // b a a
-          table->fields[index] = field->next;
-        }
-
-        table->size.all -= 1;
-        free_htfield(field);
-        return true;
-      } else if (field->next) {
-        prev = field;
-        field = field->next;
-      } else {
-        return false;
+      if (size == table->size.used) {
+        resize_hashtable(table, size);
       }
-    } while (field);
+
+      free_htfield(field);
+      return true;
+    } else {
+      index += 1;
+    }
   }
 
   return false;

--- a/src/utils/integer.c
+++ b/src/utils/integer.c
@@ -55,20 +55,20 @@ void number_pad(char *res, const uint32_t value) {
   res[2] = '\0';
 }
 
-int ltoa(const int64_t value, char *dst) {
+const int ltoa(const int64_t value, char *dst) {
   const bool neg = (value < 0);
   uint64_t uval = (neg ? -value : value);
 
   int len = 1;
-  len += (uval >= pow10_table[1]);
-  len += (uval >= pow10_table[2]);
-  len += (uval >= pow10_table[3]);
-  len += (uval >= pow10_table[4]);
-  len += (uval >= pow10_table[5]);
-  len += (uval >= pow10_table[6]);
-  len += (uval >= pow10_table[7]);
-  len += (uval >= pow10_table[8]);
-  len += (uval >= pow10_table[9]);
+  len += (uval >= pow10_table[ 1]);
+  len += (uval >= pow10_table[ 2]);
+  len += (uval >= pow10_table[ 3]);
+  len += (uval >= pow10_table[ 4]);
+  len += (uval >= pow10_table[ 5]);
+  len += (uval >= pow10_table[ 6]);
+  len += (uval >= pow10_table[ 7]);
+  len += (uval >= pow10_table[ 8]);
+  len += (uval >= pow10_table[ 9]);
   len += (uval >= pow10_table[10]);
   len += (uval >= pow10_table[11]);
   len += (uval >= pow10_table[12]);
@@ -98,4 +98,27 @@ int ltoa(const int64_t value, char *dst) {
   }
 
   return total_len;
+}
+
+const int get_digit_count(const uint64_t value) {
+  if (value >= pow10_table[19]) return 20;
+  if (value >= pow10_table[18]) return 19;
+  if (value >= pow10_table[17]) return 18;
+  if (value >= pow10_table[16]) return 17;
+  if (value >= pow10_table[15]) return 16;
+  if (value >= pow10_table[14]) return 15;
+  if (value >= pow10_table[13]) return 14;
+  if (value >= pow10_table[12]) return 13;
+  if (value >= pow10_table[11]) return 12;
+  if (value >= pow10_table[10]) return 11;
+  if (value >= pow10_table[9])  return 10;
+  if (value >= pow10_table[8])  return  9;
+  if (value >= pow10_table[7])  return  8;
+  if (value >= pow10_table[6])  return  7;
+  if (value >= pow10_table[5])  return  6;
+  if (value >= pow10_table[4])  return  5;
+  if (value >= pow10_table[3])  return  4;
+  if (value >= pow10_table[2])  return  3;
+  if (value >= pow10_table[1])  return  2;
+  return 1;
 }

--- a/src/utils/integer.c
+++ b/src/utils/integer.c
@@ -1,8 +1,31 @@
 #include <telly.h>
 
 #include <stdbool.h>
-#include <ctype.h>
 #include <stdint.h>
+#include <ctype.h>
+
+static const uint64_t pow10_table[] = {
+  1UL,
+  10UL,
+  100UL,
+  1000UL,
+  10000UL,
+  100000UL,
+  1000000UL,
+  10000000UL,
+  100000000UL,
+  1000000000UL,
+  10000000000UL,
+  100000000000UL,
+  1000000000000UL,
+  10000000000000UL,
+  100000000000000UL,
+  1000000000000000UL,
+  10000000000000000UL,
+  100000000000000000UL,
+  1000000000000000000UL,
+  10000000000000000000UL
+};
 
 bool is_integer(const char *value) {
   char *_value = (char *) value;
@@ -30,4 +53,49 @@ void number_pad(char *res, const uint32_t value) {
   }
 
   res[2] = '\0';
+}
+
+int ltoa(const int64_t value, char *dst) {
+  const bool neg = (value < 0);
+  uint64_t uval = (neg ? -value : value);
+
+  int len = 1;
+  len += (uval >= pow10_table[1]);
+  len += (uval >= pow10_table[2]);
+  len += (uval >= pow10_table[3]);
+  len += (uval >= pow10_table[4]);
+  len += (uval >= pow10_table[5]);
+  len += (uval >= pow10_table[6]);
+  len += (uval >= pow10_table[7]);
+  len += (uval >= pow10_table[8]);
+  len += (uval >= pow10_table[9]);
+  len += (uval >= pow10_table[10]);
+  len += (uval >= pow10_table[11]);
+  len += (uval >= pow10_table[12]);
+  len += (uval >= pow10_table[13]);
+  len += (uval >= pow10_table[14]);
+  len += (uval >= pow10_table[15]);
+  len += (uval >= pow10_table[16]);
+  len += (uval >= pow10_table[17]);
+  len += (uval >= pow10_table[18]);
+  len += (uval >= pow10_table[19]);
+
+  const int total_len = (len + neg);
+  dst[total_len] = '\0';
+
+  int pos = (total_len - 1);
+
+  while (uval >= 10) {
+    uint64_t q = (uval / 10);
+    dst[pos--] = ('0' + (uval - q * 10));
+    uval = q;
+  }
+
+  dst[pos] = ('0' + uval);
+
+  if (neg) {
+    dst[0] = '-';
+  }
+
+  return total_len;
 }


### PR DESCRIPTION
* Replace handling collisions method as separate chaining to linear probing for to use cache lines efficiently
* Reduce string and math operations on `HKEYS`, `HVALS`, `HGETALL` and `HSET` commands
* Fix invalid table pointer for responding on `HDEL` command