### PR TITLE
fix: add missing return value of initialize_kdf

### DIFF
--- a/src/server/auth.c
+++ b/src/server/auth.c
@@ -41,6 +41,7 @@ bool initialize_kdf() {
     OSSL_PROVIDER_unload(prov);
     OSSL_LIB_CTX_free(libctx);
     write_log(LOG_ERR, "Cannot create KDF context, because an error occured.");
+    return false;
   }
 
   EVP_KDF_free(kdf);


### PR DESCRIPTION
On error when initializing KDF (Key Derivation Function), the process of initialization continues. It must return `false` value. This PR solves this.

Resolves #7 