### PR TITLE
fix(auth): invalid size and invalid memory function on remove_password

### DIFF
--- a/src/server/auth.c
+++ b/src/server/auth.c
@@ -273,7 +273,7 @@ bool remove_password(struct Client *executor, char *value, const size_t value_le
     free_password(password);
     password_count -= 1;
 
-    memcpy(passwords + at, passwords + at + 1, (password_count - at) * sizeof(struct Password));
+    memcpy(passwords + at, passwords + at + 1, (password_count - at) * sizeof(struct Password *));
     passwords = realloc(passwords, password_count * sizeof(struct Password));
 
     return true;

--- a/src/server/auth.c
+++ b/src/server/auth.c
@@ -273,7 +273,7 @@ bool remove_password(struct Client *executor, char *value, const size_t value_le
     free_password(password);
     password_count -= 1;
 
-    memcpy(passwords + at, passwords + at + 1, (password_count - at) * sizeof(struct Password *));
+    memmove(passwords + at, passwords + at + 1, (password_count - at) * sizeof(struct Password *));
     passwords = realloc(passwords, password_count * sizeof(struct Password));
 
     return true;


### PR DESCRIPTION
* `memcpy` cannot be used when shifting, because `dst` and `src` is overlapped.
* Pointers should be transferred, not values. So, change size for pointers.

Resolves #8 