### PR TITLE
Fix misaligned `uint16_t` write by using `memcpy`

### DIFF
--- a/src/utils/integer.c
+++ b/src/utils/integer.c
@@ -58,7 +58,7 @@ uint8_t ltoa(const int64_t value, char *dst) {
     const uint64_t remainder = (uval % 100);
 
     pos -= 2;
-    *((uint16_t *) (dst + pos)) = *((uint16_t *) (TWO_DIGITS_TABLE + remainder * 2));
+    memcpy(dst + pos, TWO_DIGITS_TABLE + remainder * 2, 2);
 
     uval /= 100;
   }
@@ -69,7 +69,7 @@ uint8_t ltoa(const int64_t value, char *dst) {
 
     if (remainder >= 10) {
       pos -= 2;
-      *((uint16_t *) (dst + pos)) = chars;
+      memcpy(dst + pos, TWO_DIGITS_TABLE + remainder * 2, 2);
     } else {
       pos -= 1;
       dst[pos] = ('0' + remainder);

--- a/src/utils/integer.c
+++ b/src/utils/integer.c
@@ -65,7 +65,6 @@ uint8_t ltoa(const int64_t value, char *dst) {
 
   if (uval > 0) {
     const uint8_t remainder = uval;
-    const uint16_t chars = *((uint16_t*) (TWO_DIGITS_TABLE + remainder * 2));
 
     if (remainder >= 10) {
       pos -= 2;


### PR DESCRIPTION
Hi, I ran UBSAN and catched two UBs in `integer.c` file. Replaced the relevant parts with `memcpy` and fixed.

The issue was discovered as running these commands:

```shell
mkdir build
cd build
CC=clang cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -g" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"
cmake --build .
export UBSAN_OPTIONS=print_stacktrace=1
./telly
```

UBSAN result:

```shell
/home/savas/Desktop/forks/tellydb/src/utils/integer.c:61:5: runtime error: store to misaligned address 0x7afe2c500029 for type 'uint16_t' (aka 'unsigned short'), which requires 2 byte alignment
0x7afe2c500029: note: pointer points here
 6e 20 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00
              ^ 
    #0 0x00000059c455 in ltoa /home/savas/Desktop/forks/tellydb/src/utils/integer.c:61:33
    #1 0x0000005a0dca in generate_date_string /home/savas/Desktop/forks/tellydb/src/utils/string.c:61:3
    #2 0x00000059dfae in write_log /home/savas/Desktop/forks/tellydb/src/utils/logging.c:109:3
    #3 0x00000058fc4c in start_server /home/savas/Desktop/forks/tellydb/src/server/server.c:211:5
    #4 0x00000059293f in main /home/savas/Desktop/forks/tellydb/src/telly.c:9:7
    #5 0x7efe2e3f65b4 in __libc_start_call_main (/lib64/libc.so.6+0x35b4) (BuildId: f410d74336e800b1795d2fd97ddfd36c16ad6546)
    #6 0x7efe2e3f6667 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3667) (BuildId: f410d74336e800b1795d2fd97ddfd36c16ad6546)
    #7 0x00000042c854 in _start (/home/savas/Desktop/forks/tellydb/build/telly+0x42c854) (BuildId: 841940b83fcf070f6415829d617fefc822621891)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/savas/Desktop/forks/tellydb/src/utils/integer.c:61:5 
/home/savas/Desktop/forks/tellydb/src/utils/integer.c:72:7: runtime error: store to misaligned address 0x7afe2c500027 for type 'uint16_t' (aka 'unsigned short'), which requires 2 byte alignment
0x7afe2c500027: note: pointer points here
 4a 61 6e 20 00  00 32 36 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00
             ^ 
    #0 0x00000059c74a in ltoa /home/savas/Desktop/forks/tellydb/src/utils/integer.c:72:35
    #1 0x0000005a0dca in generate_date_string /home/savas/Desktop/forks/tellydb/src/utils/string.c:61:3
    #2 0x00000059dfae in write_log /home/savas/Desktop/forks/tellydb/src/utils/logging.c:109:3
    #3 0x00000058fc4c in start_server /home/savas/Desktop/forks/tellydb/src/server/server.c:211:5
    #4 0x00000059293f in main /home/savas/Desktop/forks/tellydb/src/telly.c:9:7
    #5 0x7efe2e3f65b4 in __libc_start_call_main (/lib64/libc.so.6+0x35b4) (BuildId: f410d74336e800b1795d2fd97ddfd36c16ad6546)
    #6 0x7efe2e3f6667 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3667) (BuildId: f410d74336e800b1795d2fd97ddfd36c16ad6546)
    #7 0x00000042c854 in _start (/home/savas/Desktop/forks/tellydb/build/telly+0x42c854) (BuildId: 841940b83fcf070f6415829d617fefc822621891)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/savas/Desktop/forks/tellydb/src/utils/integer.c:72:7 
```