### PR TITLE
Fix memory leak and UB, add NULL checks

### DIFF
--- a/src/telly.c
+++ b/src/telly.c
@@ -44,6 +44,10 @@ int main(int argc, char *argv[]) {
         return EXIT_SUCCESS;
       } else if (streq(arg, "create-config")) {
         FILE *file = fopen(".tellyconf", "w");
+        if (!file) {
+          fprintf(stderr, "Error: Cannot create .tellyconf file\n");
+          return EXIT_FAILURE;
+        }
         Config *conf = get_default_config();
         char buf[4096];
 

--- a/src/transactions/transactions.c
+++ b/src/transactions/transactions.c
@@ -127,11 +127,13 @@ void execute_transaction_block(TransactionBlock *block) {
   switch (block->type) {
     case TX_DIRECT: {
       const string_t response = execute_transaction(client, password, block->data.transaction);
-      if (response.len != 0) add_io_request(IOOP_WRITE, client, response);
+      if (response.len != 0 && client)
+        add_io_request(IOOP_WRITE, client, response);
       break;
     }
 
     case TX_MULTIPLE: {
+      if (!client) break;
       MultipleTransactions multiple = block->data.multiple;
       string_t results[multiple.transaction_count];
       uint64_t result_count = 0;

--- a/src/transactions/transactions.c
+++ b/src/transactions/transactions.c
@@ -127,13 +127,11 @@ void execute_transaction_block(TransactionBlock *block) {
   switch (block->type) {
     case TX_DIRECT: {
       const string_t response = execute_transaction(client, password, block->data.transaction);
-      if (response.len != 0 && client)
-        add_io_request(IOOP_WRITE, client, response);
+      if (response.len != 0) add_io_request(IOOP_WRITE, client, response);
       break;
     }
 
     case TX_MULTIPLE: {
-      if (!client) break;
       MultipleTransactions multiple = block->data.multiple;
       string_t results[multiple.transaction_count];
       uint64_t result_count = 0;

--- a/src/transactions/transactions.c
+++ b/src/transactions/transactions.c
@@ -152,7 +152,8 @@ void execute_transaction_block(TransactionBlock *block) {
       size_t at = get_digit_count(result_count) + 3;
       length += at;
 
-      sprintf(client->write_buf, "*%" PRIu64 "\r\n", result_count);
+      if (client != NULL && client->write_buf != NULL)
+        sprintf(client->write_buf, "*%" PRIu64 "\r\n", result_count);
 
       for (uint64_t i = 0; i < result_count; ++i) {
         string_t result = results[i];

--- a/src/utils/config.c
+++ b/src/utils/config.c
@@ -41,7 +41,8 @@ static constexpr LogLevelField log_levels_map[4] = {
 
 static inline void pass_line(FILE *file) {
   int c;
-  while (c != EOF && c != '\n') c = fgetc(file);
+  while ((c = fgetc(file)) != EOF && c != '\n')
+    ;
 }
 
 static inline void read_value(FILE *file, char *buf) {

--- a/src/utils/config.c
+++ b/src/utils/config.c
@@ -265,6 +265,10 @@ Config *get_default_config() {
 
 Config *get_config(const char *filename) {
   Config *conf = malloc(sizeof(Config));
+  if (!conf) {
+    write_log(LOG_ERR, "Allocation failed for get_config");
+    return NULL;
+  }
 
   if (filename == NULL) {
     FILE *file = fopen(".tellyconf", "r");
@@ -288,6 +292,7 @@ Config *get_config(const char *filename) {
 
       return conf;
     } else {
+      free(conf);
       return get_config(NULL);
     }
   }


### PR DESCRIPTION
Hi, NULL check guy here.

- I've noticed a memory leak in `get_config()` function. When the function falls back by calling itself, the previously allocated config memory is not freed.
- The `int c` was using before being initialized.
- And the other changes are just missing NULL checks