### PR TITLE
feat: redesign threading architecture

### DIFF
--- a/docs/SPECS.md
+++ b/docs/SPECS.md
@@ -11,10 +11,10 @@ tellydb contains a main thread (process), a transaction thread, I/O threads and 
 4. Once the close signal, deinitializes everything and ends the loop.
 
 ### I/O Threads
-tellydb spawns `max(processor count - 1, 1)` I/O threads. The architecture operates as follows:
+tellydb spawns `max(processor count - 1, 2)` I/O threads. The architecture operates as follows:
 1. Each I/O thread runs an infinite loop, continuously polling for incoming tasks.
-2. Any thread can enqueue an I/O job when need into a thread-safe queue.
-3. An available I/O thread dequeues a task from the queue.
+2. Any thread can enqueue an I/O job when need into thread-safe queue of the thread. The thread to be responsible for is selected based on `client->id`.
+3. The selected I/O thread dequeues a task from the queue.
 4. The I/O thread executes the task.
 5. The result of the task is not captured by the calling thread externally.
 

--- a/headers/server/io.h
+++ b/headers/server/io.h
@@ -13,11 +13,17 @@ enum IOOpType : uint8_t {
   IOOP_TERMINATE
 };
 
+enum IOThreadStatus {
+  IO_THREAD_ACTIVE,
+  IO_THREAD_PENDING_DESTROY,
+  IO_THREAD_DESTROYED
+};
+
 typedef struct {
   pthread_t thread;
   ThreadQueue *queue;
   event_notifier_t *notifier;
-  atomic_bool destroyed;
+  _Atomic(enum IOThreadStatus) status;
 
   // Read buffers
   char *buf;

--- a/headers/server/io.h
+++ b/headers/server/io.h
@@ -24,10 +24,6 @@ typedef struct {
   ThreadQueue *queue;
   event_notifier_t *notifier; // For catching I/O operations, used inside I/O thread
 
-  // For catching emptiness of I/O operations, used via server events
-  event_notifier_t *emptiness_notifier;
-  int emptiness_eventfd;
-
   _Atomic(enum IOThreadStatus) status;
 
   // Read buffers

--- a/headers/server/io.h
+++ b/headers/server/io.h
@@ -8,8 +8,12 @@
 typedef struct {
   pthread_t thread;
   ThreadQueue *queue;
+  Queue *prior_queue;
   event_notifier_t *notifier;
   atomic_bool destroyed;
+
+  // Current processing client id for not catching by other i/o threads
+  uint64_t client_id;
 
   // Read buffers
   char *buf;

--- a/headers/server/io.h
+++ b/headers/server/io.h
@@ -1,31 +1,29 @@
 #pragma once
 
-#include "server/client.h"
-#include "utils/string.h"
+#include "client.h"
+#include "utils/utils.h"
 
 #include <stdint.h>
+
+#include <pthread.h>
+
+enum IOOpType : uint8_t {
+  IOOP_READ,
+  IOOP_WRITE,
+  IOOP_TERMINATE
+};
 
 typedef struct {
   pthread_t thread;
   ThreadQueue *queue;
-  Queue *prior_queue;
   event_notifier_t *notifier;
   atomic_bool destroyed;
-
-  // Current processing client id for not catching by other i/o threads
-  uint64_t client_id;
 
   // Read buffers
   char *buf;
   Arena *resp_arena;
   Arena *ucmd_arena;
 } IOThread;
-
-enum IOOpType : uint8_t {
-  IOOP_GET_COMMAND,
-  IOOP_TERMINATE,
-  IOOP_WRITE
-};
 
 int create_io_threads();
 void send_destroy_signal_to_io_threads();

--- a/headers/server/io.h
+++ b/headers/server/io.h
@@ -5,6 +5,18 @@
 
 #include <stdint.h>
 
+typedef struct {
+  pthread_t thread;
+  ThreadQueue *queue;
+  event_notifier_t *notifier;
+  atomic_bool destroyed;
+
+  // Read buffers
+  char *buf;
+  Arena *resp_arena;
+  Arena *ucmd_arena;
+} IOThread;
+
 enum IOOpType : uint8_t {
   IOOP_GET_COMMAND,
   IOOP_TERMINATE,

--- a/headers/server/io.h
+++ b/headers/server/io.h
@@ -23,7 +23,11 @@ typedef struct {
   pthread_t thread;
   ThreadQueue *queue;
   event_notifier_t *notifier; // For catching I/O operations, used inside I/O thread
-  event_notifier_t *server_notifier; // For catching emptiness of I/O operations, used inside server
+
+  // For catching emptiness of I/O operations, used via server events
+  event_notifier_t *emptiness_notifier;
+  int emptiness_eventfd;
+
   _Atomic(enum IOThreadStatus) status;
 
   // Read buffers

--- a/headers/server/io.h
+++ b/headers/server/io.h
@@ -22,7 +22,8 @@ enum IOThreadStatus {
 typedef struct {
   pthread_t thread;
   ThreadQueue *queue;
-  event_notifier_t *notifier;
+  event_notifier_t *notifier; // For catching I/O operations, used inside I/O thread
+  event_notifier_t *server_notifier; // For catching emptiness of I/O operations, used inside server
   _Atomic(enum IOThreadStatus) status;
 
   // Read buffers
@@ -31,6 +32,9 @@ typedef struct {
   Arena *ucmd_arena;
 } IOThread;
 
+IOThread *get_io_threads();
+int64_t get_io_thread_count();
+
 int create_io_threads();
 void send_destroy_signal_to_io_threads();
-void add_io_request(const enum IOOpType type, Client *client, string_t write_str);
+int add_io_request(const enum IOOpType type, Client *client, string_t write_str);

--- a/headers/server/io.h
+++ b/headers/server/io.h
@@ -11,6 +11,6 @@ enum IOOpType : uint8_t {
   IOOP_WRITE
 };
 
-int create_io_thread();
-void destroy_io_thread();
+int create_io_threads();
+void send_destroy_signal_to_io_threads();
 void add_io_request(const enum IOOpType type, Client *client, string_t write_str);

--- a/headers/server/server.h
+++ b/headers/server/server.h
@@ -32,8 +32,6 @@ typedef struct {
   int eventfd;
   int sockfd;
 
-  int io_eventfd;
-
   SSL_CTX *ctx;
   Config *conf;
   time_t start_at;

--- a/headers/server/server.h
+++ b/headers/server/server.h
@@ -14,6 +14,12 @@
 
 #include <openssl/crypto.h>
 
+#include "io.h"     // IWYU pragma: export
+#include "macros.h" // IWYU pragma: export
+#include "client.h" // IWYU pragma: export
+
+#define INITIAL_UNKNOWN_COMMAND_ARENA_SIZE 8192
+
 typedef enum {
   SERVER_STATUS_NONE = 0,
   SERVER_STATUS_STARTING,
@@ -48,10 +54,4 @@ int read_from_socket(Client *client, char *buf, const size_t nbytes);
 int write_to_socket(Client *client, char *buf, const size_t nbytes);
 string_t write_value(void *value, const enum TellyTypes type, const enum ProtocolVersion protover, char *buffer);
 
-int initialize_read_buffers();
-void free_read_buffers();
-void read_command(Client *client);
-
-#include "io.h"     // IWYU pragma: export
-#include "macros.h" // IWYU pragma: export
-#include "client.h" // IWYU pragma: export
+void read_command(IOThread *thread, Client *client);

--- a/headers/server/server.h
+++ b/headers/server/server.h
@@ -31,6 +31,9 @@ typedef enum {
 typedef struct {
   int eventfd;
   int sockfd;
+
+  int io_eventfd;
+
   SSL_CTX *ctx;
   Config *conf;
   time_t start_at;

--- a/src/server/events.c
+++ b/src/server/events.c
@@ -98,7 +98,7 @@ void handle_events() {
       }
 
       Client *client = GET_EVENT_DATA(events[i]);
-      add_io_request(IOOP_GET_COMMAND, client, EMPTY_STRING());
+      add_io_request(IOOP_READ, client, EMPTY_STRING());
 
       if (IS_CONNECTION_CLOSED(events[i])) add_io_request(IOOP_TERMINATE, client, EMPTY_STRING());
     }

--- a/src/server/events.c
+++ b/src/server/events.c
@@ -112,9 +112,12 @@ void handle_events() {
     for (int64_t i = 0; i < io_thread_count; ++i) {
       if (used_threads[i] == false) continue;
 
+      IOThread *threads = get_io_threads();
+
       // Wait thread to complete its jobs
-      WAIT_EVENTS(server->io_eventfd, emptiness_event, 1, -1);
-      consume_notifier(get_io_threads()[i].server_notifier);
+      WAIT_EVENTS(threads[i].emptiness_eventfd, emptiness_event, 1, -1);
+      int x = consume_notifier(threads[i].emptiness_notifier);
+      if (x == 0) printf("x: %d\n", x);
 
       used_threads[i] = false;
     }

--- a/src/server/events.c
+++ b/src/server/events.c
@@ -1,3 +1,5 @@
+#include "server/io.h"
+#include <stdint.h>
 #include <telly.h>
 
 static inline int accept_client() {
@@ -69,17 +71,18 @@ static inline int accept_client() {
 // TODO: thread-race for transactions, some executions will not be executed for inline commands
 void handle_events() {
   const uint32_t event_capacity = server->conf->max_clients + 2; // sockfd + empty for safety
-  event_t events[256];
+  event_t events[256], emptiness_event[1];
 
   const int sockfd = server->sockfd;
   const int eventfd = server->eventfd;
   struct Command *commands = server->commands;
 
-  int timeout = -1;
+  const int64_t io_thread_count = get_io_thread_count();
+  int used_threads[io_thread_count];
+  for (int64_t i = 0; i < io_thread_count; ++i) used_threads[i] = false;
 
   while (!server->closed) {
-    const int nfds = WAIT_EVENTS(eventfd, events, 256, timeout);
-    int processed = nfds;
+    const int nfds = WAIT_EVENTS(eventfd, events, 256, -1);
 
     for (int i = 0; i < nfds; ++i) {
       __builtin_prefetch(&events[i + 1], 0, 0);
@@ -92,17 +95,28 @@ void handle_events() {
         }
 
         // If client cannot be accepted, it continues already. No need condition.
-        while (accept_client() != -1) processed++;
-        processed--;
+        while (accept_client() != -1);
         continue;
       }
 
       Client *client = GET_EVENT_DATA(events[i]);
-      add_io_request(IOOP_READ, client, EMPTY_STRING());
+      int io_thread_idx = add_io_request(IOOP_READ, client, EMPTY_STRING());
 
       if (IS_CONNECTION_CLOSED(events[i])) add_io_request(IOOP_TERMINATE, client, EMPTY_STRING());
+
+      // io_thread_idx value is determined by client->id, so no need for making individual handling for IOOP_TERMINATE
+      if (io_thread_idx != -1)
+        used_threads[io_thread_idx] = true;
     }
 
-    timeout = 32 - (processed * 32 / 256);
+    for (int64_t i = 0; i < io_thread_count; ++i) {
+      if (used_threads[i] == false) continue;
+
+      // Wait thread to complete its jobs
+      WAIT_EVENTS(server->io_eventfd, emptiness_event, 1, -1);
+      consume_notifier(get_io_threads()[i].server_notifier);
+
+      used_threads[i] = false;
+    }
   }
 }

--- a/src/server/events.c
+++ b/src/server/events.c
@@ -1,5 +1,3 @@
-#include "server/io.h"
-#include <stdint.h>
 #include <telly.h>
 
 static inline int accept_client() {
@@ -71,15 +69,11 @@ static inline int accept_client() {
 // TODO: thread-race for transactions, some executions will not be executed for inline commands
 void handle_events() {
   const uint32_t event_capacity = server->conf->max_clients + 2; // sockfd + empty for safety
-  event_t events[256], emptiness_event[1];
+  event_t events[256];
 
   const int sockfd = server->sockfd;
   const int eventfd = server->eventfd;
   struct Command *commands = server->commands;
-
-  const int64_t io_thread_count = get_io_thread_count();
-  int used_threads[io_thread_count];
-  for (int64_t i = 0; i < io_thread_count; ++i) used_threads[i] = false;
 
   while (!server->closed) {
     const int nfds = WAIT_EVENTS(eventfd, events, 256, -1);
@@ -103,23 +97,6 @@ void handle_events() {
       int io_thread_idx = add_io_request(IOOP_READ, client, EMPTY_STRING());
 
       if (IS_CONNECTION_CLOSED(events[i])) add_io_request(IOOP_TERMINATE, client, EMPTY_STRING());
-
-      // io_thread_idx value is determined by client->id, so no need for making individual handling for IOOP_TERMINATE
-      if (io_thread_idx != -1)
-        used_threads[io_thread_idx] = true;
-    }
-
-    for (int64_t i = 0; i < io_thread_count; ++i) {
-      if (used_threads[i] == false) continue;
-
-      IOThread *threads = get_io_threads();
-
-      // Wait thread to complete its jobs
-      WAIT_EVENTS(threads[i].emptiness_eventfd, emptiness_event, 1, -1);
-      int x = consume_notifier(threads[i].emptiness_notifier);
-      if (x == 0) printf("x: %d\n", x);
-
-      used_threads[i] = false;
     }
   }
 }

--- a/src/server/io.c
+++ b/src/server/io.c
@@ -14,6 +14,14 @@ static sigset_t set;
 
 void *io_thread_procedure(void *arg);
 
+IOThread *get_io_threads() {
+  return io_threads;
+}
+
+int64_t get_io_thread_count() {
+  return io_thread_count;
+}
+
 int create_io_threads() {
   assert(sigemptyset(&set) == 0);
   assert(sigaddset(&set, SIGINT) == 0);
@@ -29,6 +37,7 @@ int create_io_threads() {
     IOThread *io_thread = &io_threads[succeed];
 
     event_notifier_t *notifier = (io_thread->notifier = create_notifier());
+    event_notifier_t *server_notifier = (io_thread->server_notifier = create_notifier());
     ThreadQueue *queue = (io_thread->queue = create_tqueue(IO_QUEUE_SIZE, sizeof(IOOperation), alignof(IOOperation)));
 
     char *buf = (io_thread->buf = malloc(RESP_BUF_SIZE));
@@ -38,6 +47,7 @@ int create_io_threads() {
     if (notifier == NULL || queue == NULL || buf == NULL || ucmd_arena == NULL || resp_arena == NULL) {
       CLEANUP_THREAD:
       if (notifier) destroy_notifier(notifier);
+      if (server_notifier) destroy_notifier(server_notifier);
       if (queue) free_tqueue(queue);
 
       if (buf) free(buf);
@@ -75,10 +85,11 @@ void send_destroy_signal_to_io_threads() {
   free(io_threads);
 }
 
-void add_io_request(const enum IOOpType type, Client *client, string_t to_write) {
-  if (client->id == -1) return;
+int add_io_request(const enum IOOpType type, Client *client, string_t to_write) {
+  if (client->id == -1) return -1;
 
-  IOThread *selected = &io_threads[client->id % io_thread_count];
+  int thread_idx = (client->id % io_thread_count);
+  IOThread *selected = &io_threads[thread_idx];
 
   IOOperation op = {
     .type = type,
@@ -91,13 +102,15 @@ void add_io_request(const enum IOOpType type, Client *client, string_t to_write)
 
   push_tqueue(selected->queue, &op);
   signal_notifier(selected->notifier, 1);
+
+  return thread_idx;
 }
 
 void *io_thread_procedure(void *arg) {
   assert(pthread_sigmask(SIG_BLOCK, &set, NULL) == 0);
 
   IOThread *thread = (IOThread *) arg;
-  int added = -1, efd = -1;
+  int emptiness_added = -1, added = -1, efd = -1;
 
   efd = CREATE_EVENTFD();
   if (efd == -1) goto DESTROY;
@@ -109,6 +122,14 @@ void *io_thread_procedure(void *arg) {
 
   added = ADD_EVENT(efd, fd, event);
   if (added == -1) goto DESTROY;
+
+  const int emptiness_fd = get_notifier(thread->server_notifier);
+
+  event_t emptiness_event;
+  CREATE_EVENT(emptiness_event, emptiness_fd);
+
+  emptiness_added = ADD_EVENT(server->io_eventfd, emptiness_fd, emptiness_event);
+  if (emptiness_added == -1) goto DESTROY;
 
   // There is exactly one fd/notifier
   event_t events[1];
@@ -140,6 +161,8 @@ void *io_thread_procedure(void *arg) {
           break;
       }
     }
+
+    signal_notifier(thread->server_notifier, 1);
   }
 
 DESTROY:
@@ -149,8 +172,15 @@ DESTROY:
     REMOVE_EVENT(efd, fd);
   }
 
+  if (emptiness_added != -1) {
+    event_t ev;
+    PREPARE_REMOVING_EVENT(ev, emptiness_added);
+    REMOVE_EVENT(server->io_eventfd, emptiness_added);
+  }
+
   if (efd != -1) close(efd);
   destroy_notifier(thread->notifier);
+  destroy_notifier(thread->server_notifier);
   free_tqueue(thread->queue);
 
   free(thread->buf);

--- a/src/server/io.c
+++ b/src/server/io.c
@@ -37,10 +37,6 @@ int create_io_threads() {
     IOThread *io_thread = &io_threads[succeed];
 
     event_notifier_t *notifier = (io_thread->notifier = create_notifier());
-
-    event_notifier_t *emptiness_notifier = (io_thread->emptiness_notifier = create_notifier());
-    const int emptiness_eventfd = (io_thread->emptiness_eventfd = CREATE_EVENTFD());
-
     ThreadQueue *queue = (io_thread->queue = create_tqueue(IO_QUEUE_SIZE, sizeof(IOOperation), alignof(IOOperation)));
 
     char *buf = (io_thread->buf = malloc(RESP_BUF_SIZE));
@@ -51,9 +47,6 @@ int create_io_threads() {
       CLEANUP_THREAD:
       if (notifier) destroy_notifier(notifier);
       if (queue) free_tqueue(queue);
-
-      if (emptiness_notifier) destroy_notifier(emptiness_notifier);
-      if (emptiness_eventfd == -1) close(emptiness_eventfd);
 
       if (buf) free(buf);
       if (ucmd_arena) arena_destroy(ucmd_arena);
@@ -115,7 +108,7 @@ void *io_thread_procedure(void *arg) {
   assert(pthread_sigmask(SIG_BLOCK, &set, NULL) == 0);
 
   IOThread *thread = (IOThread *) arg;
-  int emptiness_added = -1, added = -1, efd = -1;
+  int added = -1, efd = -1;
 
   efd = CREATE_EVENTFD();
   if (efd == -1) goto DESTROY;
@@ -127,14 +120,6 @@ void *io_thread_procedure(void *arg) {
 
   added = ADD_EVENT(efd, fd, event);
   if (added == -1) goto DESTROY;
-
-  const int emptiness_fd = get_notifier(thread->emptiness_notifier);
-
-  event_t emptiness_event;
-  CREATE_EVENT(emptiness_event, emptiness_fd);
-
-  emptiness_added = ADD_EVENT(thread->emptiness_eventfd, emptiness_fd, emptiness_event);
-  if (emptiness_added == -1) goto DESTROY;
 
   // There is exactly one fd/notifier
   event_t events[1];
@@ -166,8 +151,6 @@ void *io_thread_procedure(void *arg) {
           break;
       }
     }
-
-    signal_notifier(thread->emptiness_notifier, 1);
   }
 
 DESTROY:
@@ -177,19 +160,10 @@ DESTROY:
     REMOVE_EVENT(efd, fd);
   }
 
-  if (emptiness_added != -1) {
-    event_t ev;
-    PREPARE_REMOVING_EVENT(ev, emptiness_added);
-    REMOVE_EVENT(thread->emptiness_eventfd, emptiness_added);
-  }
-
   if (efd != -1) close(efd);
 
   destroy_notifier(thread->notifier);
   free_tqueue(thread->queue);
-
-  destroy_notifier(thread->emptiness_notifier);
-  close(thread->emptiness_eventfd);
 
   free(thread->buf);
   arena_destroy(thread->resp_arena);

--- a/src/server/io.c
+++ b/src/server/io.c
@@ -31,7 +31,6 @@ int create_io_threads() {
     const int code = pthread_create(&io_thread->thread, NULL, io_thread_procedure, io_thread);
     event_notifier_t *notifier = (io_thread->notifier = create_notifier());
     ThreadQueue *queue = (io_thread->queue = create_tqueue(IO_QUEUE_SIZE, sizeof(IOOperation), alignof(IOOperation)));
-    Queue *prior_queue = (io_thread->prior_queue = create_queue(io_thread_count - 1, sizeof(IOOperation), alignof(IOOperation)));
 
     char *buf = (io_thread->buf = malloc(RESP_BUF_SIZE));
     Arena *ucmd_arena = (io_thread->ucmd_arena = arena_create(INITIAL_UNKNOWN_COMMAND_ARENA_SIZE));
@@ -40,7 +39,6 @@ int create_io_threads() {
     if (notifier == NULL || queue == NULL || buf == NULL || ucmd_arena == NULL || resp_arena == NULL || code == EAGAIN) {
       if (notifier) destroy_notifier(notifier);
       if (queue) free_tqueue(queue);
-      if (prior_queue) free_queue(prior_queue);
 
       if (buf) free(buf);
       if (ucmd_arena) arena_destroy(ucmd_arena);
@@ -66,15 +64,7 @@ void send_destroy_signal_to_io_threads() {
 }
 
 void add_io_request(const enum IOOpType type, Client *client, string_t to_write) {
-  IOThread *selected = &io_threads[0];
-
-  for (int64_t i = 1; i < io_thread_count; ++i) {
-    IOThread *thread = &io_threads[i];
-
-    if (estimate_tqueue_size(selected->queue) > estimate_tqueue_size(thread->queue)) {
-      selected = thread;
-    }
-  }
+  IOThread *selected = &io_threads[client->id % io_thread_count];
 
   IOOperation op = {
     .type = type,
@@ -103,8 +93,6 @@ void *io_thread_procedure(void *arg) {
   added = ADD_EVENT(efd, fd, event);
   if (added == -1) goto DESTROY;
 
-  int k = 0;
-
   // There is exactly one fd/notifier
   event_t events[1];
 
@@ -116,40 +104,17 @@ void *io_thread_procedure(void *arg) {
 
     for (uint64_t i = 0; i < count; ++i) {
       IOOperation op;
-      if (thread->prior_queue->size != 0) {
-        k += 1;
-        op = *((IOOperation *) pop_queue(thread->prior_queue));
-      } else {
-        if (!pop_tqueue(thread->queue, &op)) break;
-      }
+      if (!pop_tqueue(thread->queue, &op)) break;
 
       Client *client = op.client;
       if (client->id == -1) continue;
-
-      bool processing = false;
-      for (uint64_t j = 0; j < io_thread_count; ++j) {
-        if (io_threads[j].client_id == client->id) {
-          processing = true;
-          signal_notifier(thread->notifier, 1);
-          break;
-        }
-      }
-
-      // This client is processing already by another I/O thread
-      if (processing) {
-        push_queue(thread->prior_queue, &op);
-        usleep(1); // TODO: need to be find better way
-        continue;
-      }
-
-      thread->client_id = client->id;
 
       switch (op.type) {
         case IOOP_TERMINATE:
           terminate_connection(client);
           break;
 
-        case IOOP_GET_COMMAND:
+        case IOOP_READ:
           read_command(thread, client);
           break;
 
@@ -157,13 +122,10 @@ void *io_thread_procedure(void *arg) {
           write_to_socket(client, op.to_write.value, op.to_write.len);
           break;
       }
-
-      thread->client_id = -1;
     }
   }
 
 DESTROY:
-  printf("k: %d\n", k);
   if (added != -1) {
     event_t ev;
     PREPARE_REMOVING_EVENT(ev, fd);
@@ -173,7 +135,6 @@ DESTROY:
   if (efd != -1) close(efd);
   destroy_notifier(thread->notifier);
   free_tqueue(thread->queue);
-  free_queue(thread->prior_queue);
 
   free(thread->buf);
   arena_destroy(thread->resp_arena);

--- a/src/server/io.c
+++ b/src/server/io.c
@@ -64,7 +64,7 @@ void add_io_request(const enum IOOpType type, Client *client, string_t to_write)
   // TODO
 }
 
-void *io_thread(void *arg) {
+void *io_thread_procedure(void *arg) {
   assert(pthread_sigmask(SIG_BLOCK, &set, NULL) == 0);
 
   IOThread *thread = (IOThread *) arg;

--- a/src/server/io.c
+++ b/src/server/io.c
@@ -83,7 +83,10 @@ void add_io_request(const enum IOOpType type, Client *client, string_t to_write)
   IOOperation op = {
     .type = type,
     .client = client,
-    .to_write = RESP_OK_MESSAGE("PONG") // need to be replaced with to_write
+
+    // In transaction thread, each `to_write` value will be stored independenly already.
+    // Storing in extra layer (here) is redundant.
+    .to_write = to_write
   };
 
   push_tqueue(selected->queue, &op);

--- a/src/server/io.c
+++ b/src/server/io.c
@@ -28,7 +28,6 @@ int create_io_threads() {
   while (succeed != io_thread_count) {
     IOThread *io_thread = &io_threads[succeed];
 
-    const int code = pthread_create(&io_thread->thread, NULL, io_thread_procedure, io_thread);
     event_notifier_t *notifier = (io_thread->notifier = create_notifier());
     ThreadQueue *queue = (io_thread->queue = create_tqueue(IO_QUEUE_SIZE, sizeof(IOOperation), alignof(IOOperation)));
 
@@ -36,7 +35,8 @@ int create_io_threads() {
     Arena *ucmd_arena = (io_thread->ucmd_arena = arena_create(INITIAL_UNKNOWN_COMMAND_ARENA_SIZE));
     Arena *resp_arena = (io_thread->resp_arena = arena_create(INITIAL_RESP_ARENA_SIZE));
 
-    if (notifier == NULL || queue == NULL || buf == NULL || ucmd_arena == NULL || resp_arena == NULL || code == EAGAIN) {
+    if (notifier == NULL || queue == NULL || buf == NULL || ucmd_arena == NULL || resp_arena == NULL) {
+      CLEANUP_THREAD:
       if (notifier) destroy_notifier(notifier);
       if (queue) free_tqueue(queue);
 
@@ -48,8 +48,11 @@ int create_io_threads() {
     }
 
     atomic_init(&io_thread->destroyed, false);
-    assert(pthread_detach(io_thread->thread) == 0);
 
+    const int code = pthread_create(&io_thread->thread, NULL, io_thread_procedure, io_thread);
+    if (code == EAGAIN) goto CLEANUP_THREAD;
+
+    assert(pthread_detach(io_thread->thread) == 0);
     succeed += 1;
   }
 

--- a/src/server/io.c
+++ b/src/server/io.c
@@ -78,7 +78,7 @@ void send_destroy_signal_to_io_threads() {
   WAIT_DESTROYED:
   usleep(10);
   for (int64_t i = 0; i < io_thread_count; ++i) {
-    if (atomic_load_explicit(&io_threads[i].status, memory_order_relaxed) != IO_THREAD_DESTROYED)
+    if (atomic_load_explicit(&io_threads[i].status, memory_order_acquire) != IO_THREAD_DESTROYED)
       goto WAIT_DESTROYED;
   }
 
@@ -187,6 +187,6 @@ DESTROY:
   arena_destroy(thread->resp_arena);
   arena_destroy(thread->ucmd_arena);
 
-  atomic_store_explicit(&thread->status, IO_THREAD_DESTROYED, memory_order_relaxed);
+  atomic_store_explicit(&thread->status, IO_THREAD_DESTROYED, memory_order_release);
   return NULL;
 }

--- a/src/server/io.c
+++ b/src/server/io.c
@@ -31,6 +31,8 @@ int create_io_threads() {
     const int code = pthread_create(&io_thread->thread, NULL, io_thread_procedure, io_thread);
     event_notifier_t *notifier = (io_thread->notifier = create_notifier());
     ThreadQueue *queue = (io_thread->queue = create_tqueue(IO_QUEUE_SIZE, sizeof(IOOperation), alignof(IOOperation)));
+    Queue *prior_queue = (io_thread->prior_queue = create_queue(io_thread_count - 1, sizeof(IOOperation), alignof(IOOperation)));
+
     char *buf = (io_thread->buf = malloc(RESP_BUF_SIZE));
     Arena *ucmd_arena = (io_thread->ucmd_arena = arena_create(INITIAL_UNKNOWN_COMMAND_ARENA_SIZE));
     Arena *resp_arena = (io_thread->resp_arena = arena_create(INITIAL_RESP_ARENA_SIZE));
@@ -38,6 +40,8 @@ int create_io_threads() {
     if (notifier == NULL || queue == NULL || buf == NULL || ucmd_arena == NULL || resp_arena == NULL || code == EAGAIN) {
       if (notifier) destroy_notifier(notifier);
       if (queue) free_tqueue(queue);
+      if (prior_queue) free_queue(prior_queue);
+
       if (buf) free(buf);
       if (ucmd_arena) arena_destroy(ucmd_arena);
       if (resp_arena) arena_destroy(resp_arena);
@@ -99,6 +103,8 @@ void *io_thread_procedure(void *arg) {
   added = ADD_EVENT(efd, fd, event);
   if (added == -1) goto DESTROY;
 
+  int k = 0;
+
   // There is exactly one fd/notifier
   event_t events[1];
 
@@ -110,10 +116,33 @@ void *io_thread_procedure(void *arg) {
 
     for (uint64_t i = 0; i < count; ++i) {
       IOOperation op;
-      if (!pop_tqueue(thread->queue, &op)) break;
+      if (thread->prior_queue->size != 0) {
+        k += 1;
+        op = *((IOOperation *) pop_queue(thread->prior_queue));
+      } else {
+        if (!pop_tqueue(thread->queue, &op)) break;
+      }
 
       Client *client = op.client;
       if (client->id == -1) continue;
+
+      bool processing = false;
+      for (uint64_t j = 0; j < io_thread_count; ++j) {
+        if (io_threads[j].client_id == client->id) {
+          processing = true;
+          signal_notifier(thread->notifier, 1);
+          break;
+        }
+      }
+
+      // This client is processing already by another I/O thread
+      if (processing) {
+        push_queue(thread->prior_queue, &op);
+        usleep(1); // TODO: need to be find better way
+        continue;
+      }
+
+      thread->client_id = client->id;
 
       switch (op.type) {
         case IOOP_TERMINATE:
@@ -128,10 +157,13 @@ void *io_thread_procedure(void *arg) {
           write_to_socket(client, op.to_write.value, op.to_write.len);
           break;
       }
+
+      thread->client_id = -1;
     }
   }
 
 DESTROY:
+  printf("k: %d\n", k);
   if (added != -1) {
     event_t ev;
     PREPARE_REMOVING_EVENT(ev, fd);
@@ -141,6 +173,7 @@ DESTROY:
   if (efd != -1) close(efd);
   destroy_notifier(thread->notifier);
   free_tqueue(thread->queue);
+  free_queue(thread->prior_queue);
 
   free(thread->buf);
   arena_destroy(thread->resp_arena);

--- a/src/server/io.c
+++ b/src/server/io.c
@@ -8,14 +8,7 @@ typedef struct {
   string_t to_write;
 } IOOperation;
 
-typedef struct {
-  pthread_t thread;
-  ThreadQueue *queue;
-  event_notifier_t *notifier;
-  atomic_bool destroyed;
-} IOThread;
-
-static IOThread *io_threads = NULL;
+IOThread *io_threads = NULL;
 static int64_t io_thread_count = 0;
 static sigset_t set;
 
@@ -35,13 +28,21 @@ int create_io_threads() {
   while (succeed != io_thread_count) {
     IOThread *io_thread = &io_threads[succeed];
 
-    const int code = pthread_create(&io_thread->thread, NULL, io_thread_procedure, &io_thread);
+    const int code = pthread_create(&io_thread->thread, NULL, io_thread_procedure, io_thread);
     event_notifier_t *notifier = (io_thread->notifier = create_notifier());
     ThreadQueue *queue = (io_thread->queue = create_tqueue(IO_QUEUE_SIZE, sizeof(IOOperation), alignof(IOOperation)));
+    char *buf = (io_thread->buf = malloc(RESP_BUF_SIZE));
+    Arena *ucmd_arena = (io_thread->ucmd_arena = arena_create(INITIAL_UNKNOWN_COMMAND_ARENA_SIZE));
+    Arena *resp_arena = (io_thread->resp_arena = arena_create(INITIAL_RESP_ARENA_SIZE));
 
-    if (notifier == NULL || queue == NULL || code == EAGAIN) {
+    if (notifier == NULL || queue == NULL || buf == NULL || ucmd_arena == NULL || resp_arena == NULL || code == EAGAIN) {
       if (notifier) destroy_notifier(notifier);
       if (queue) free_tqueue(queue);
+      if (buf) free(buf);
+      if (ucmd_arena) arena_destroy(ucmd_arena);
+      if (resp_arena) arena_destroy(resp_arena);
+
+      break;
     }
 
     atomic_init(&io_thread->destroyed, false);
@@ -50,7 +51,7 @@ int create_io_threads() {
     succeed += 1;
   }
 
-  return 0;
+  return succeed;
 }
 
 void send_destroy_signal_to_io_threads() {
@@ -81,8 +82,6 @@ void *io_thread_procedure(void *arg) {
   added = ADD_EVENT(efd, fd, event);
   if (added == -1) goto DESTROY;
 
-  if (initialize_read_buffers() == -1) goto DESTROY;
-
   // There is exactly one fd/notifier
   event_t events[1];
 
@@ -105,7 +104,7 @@ void *io_thread_procedure(void *arg) {
           break;
 
         case IOOP_GET_COMMAND:
-          read_command(client);
+          read_command(thread, client);
           break;
 
         case IOOP_WRITE:
@@ -125,7 +124,10 @@ DESTROY:
   if (efd != -1) close(efd);
   destroy_notifier(thread->notifier);
   free_tqueue(thread->queue);
-  free_read_buffers();
+
+  free(thread->buf);
+  arena_destroy(thread->resp_arena);
+  arena_destroy(thread->ucmd_arena);
 
   return NULL;
 }

--- a/src/server/io.c
+++ b/src/server/io.c
@@ -79,6 +79,7 @@ void add_io_request(const enum IOOpType type, Client *client, string_t to_write)
   };
 
   push_tqueue(selected->queue, &op);
+  signal_notifier(selected->notifier, 1);
 }
 
 void *io_thread_procedure(void *arg) {

--- a/src/server/io.c
+++ b/src/server/io.c
@@ -62,7 +62,23 @@ void send_destroy_signal_to_io_threads() {
 }
 
 void add_io_request(const enum IOOpType type, Client *client, string_t to_write) {
-  // TODO
+  IOThread *selected = &io_threads[0];
+
+  for (int64_t i = 1; i < io_thread_count; ++i) {
+    IOThread *thread = &io_threads[i];
+
+    if (estimate_tqueue_size(selected->queue) > estimate_tqueue_size(thread->queue)) {
+      selected = thread;
+    }
+  }
+
+  IOOperation op = {
+    .type = type,
+    .client = client,
+    .to_write = RESP_OK_MESSAGE("PONG") // need to be replaced with to_write
+  };
+
+  push_tqueue(selected->queue, &op);
 }
 
 void *io_thread_procedure(void *arg) {

--- a/src/server/io.c
+++ b/src/server/io.c
@@ -37,7 +37,10 @@ int create_io_threads() {
     IOThread *io_thread = &io_threads[succeed];
 
     event_notifier_t *notifier = (io_thread->notifier = create_notifier());
-    event_notifier_t *server_notifier = (io_thread->server_notifier = create_notifier());
+
+    event_notifier_t *emptiness_notifier = (io_thread->emptiness_notifier = create_notifier());
+    const int emptiness_eventfd = (io_thread->emptiness_eventfd = CREATE_EVENTFD());
+
     ThreadQueue *queue = (io_thread->queue = create_tqueue(IO_QUEUE_SIZE, sizeof(IOOperation), alignof(IOOperation)));
 
     char *buf = (io_thread->buf = malloc(RESP_BUF_SIZE));
@@ -47,8 +50,10 @@ int create_io_threads() {
     if (notifier == NULL || queue == NULL || buf == NULL || ucmd_arena == NULL || resp_arena == NULL) {
       CLEANUP_THREAD:
       if (notifier) destroy_notifier(notifier);
-      if (server_notifier) destroy_notifier(server_notifier);
       if (queue) free_tqueue(queue);
+
+      if (emptiness_notifier) destroy_notifier(emptiness_notifier);
+      if (emptiness_eventfd == -1) close(emptiness_eventfd);
 
       if (buf) free(buf);
       if (ucmd_arena) arena_destroy(ucmd_arena);
@@ -123,12 +128,12 @@ void *io_thread_procedure(void *arg) {
   added = ADD_EVENT(efd, fd, event);
   if (added == -1) goto DESTROY;
 
-  const int emptiness_fd = get_notifier(thread->server_notifier);
+  const int emptiness_fd = get_notifier(thread->emptiness_notifier);
 
   event_t emptiness_event;
   CREATE_EVENT(emptiness_event, emptiness_fd);
 
-  emptiness_added = ADD_EVENT(server->io_eventfd, emptiness_fd, emptiness_event);
+  emptiness_added = ADD_EVENT(thread->emptiness_eventfd, emptiness_fd, emptiness_event);
   if (emptiness_added == -1) goto DESTROY;
 
   // There is exactly one fd/notifier
@@ -162,7 +167,7 @@ void *io_thread_procedure(void *arg) {
       }
     }
 
-    signal_notifier(thread->server_notifier, 1);
+    signal_notifier(thread->emptiness_notifier, 1);
   }
 
 DESTROY:
@@ -175,13 +180,16 @@ DESTROY:
   if (emptiness_added != -1) {
     event_t ev;
     PREPARE_REMOVING_EVENT(ev, emptiness_added);
-    REMOVE_EVENT(server->io_eventfd, emptiness_added);
+    REMOVE_EVENT(thread->emptiness_eventfd, emptiness_added);
   }
 
   if (efd != -1) close(efd);
+
   destroy_notifier(thread->notifier);
-  destroy_notifier(thread->server_notifier);
   free_tqueue(thread->queue);
+
+  destroy_notifier(thread->emptiness_notifier);
+  close(thread->emptiness_eventfd);
 
   free(thread->buf);
   arena_destroy(thread->resp_arena);

--- a/src/server/io.c
+++ b/src/server/io.c
@@ -1,8 +1,6 @@
 #include <telly.h>
 
-static ThreadQueue *queue = NULL;
-static event_notifier_t *notifier = NULL;
-static atomic_bool destroyed = false;
+#define IO_QUEUE_SIZE 512
 
 typedef struct {
   enum IOOpType type;
@@ -10,86 +8,72 @@ typedef struct {
   string_t to_write;
 } IOOperation;
 
-void *io_thread(void *arg);
-
-int create_io_thread() {
-  sigset_t *set = malloc(sizeof(sigset_t));
-  if (set == NULL) return -1;
-
-  assert(sigemptyset(set) == 0);
-  assert(sigaddset(set, SIGINT) == 0);
-  assert(sigaddset(set, SIGTERM) == 0);
-
-  notifier = create_notifier();
-  if (notifier == NULL) {
-    free(set);
-    return -1;
-  }
-
-  queue = create_tqueue(512, sizeof(IOOperation), alignof(IOOperation));
-  if (queue == NULL) {
-    free(set);
-    destroy_notifier(notifier);
-    return -1;
-  }
-
+typedef struct {
   pthread_t thread;
-  const int code = pthread_create(&thread, NULL, io_thread, set);
+  ThreadQueue *queue;
+  event_notifier_t *notifier;
+  atomic_bool destroyed;
+} IOThread;
 
-  switch (code) {
-    case EAGAIN:
-      free(set);
-      destroy_notifier(notifier);
-      free_tqueue(queue);
-      return -1;
+static IOThread *io_threads = NULL;
+static int64_t io_thread_count = 0;
+static sigset_t set;
 
-    default:
-      break;
+void *io_thread_procedure(void *arg);
+
+int create_io_threads() {
+  assert(sigemptyset(&set) == 0);
+  assert(sigaddset(&set, SIGINT) == 0);
+  assert(sigaddset(&set, SIGTERM) == 0);
+
+  io_thread_count = max(sysconf(_SC_NPROCESSORS_ONLN) - 1, 2);
+  io_threads = malloc(io_thread_count * sizeof(IOThread));
+  if (io_threads == NULL) return -1;
+
+  int64_t succeed = 0;
+
+  while (succeed != io_thread_count) {
+    IOThread *io_thread = &io_threads[succeed];
+
+    const int code = pthread_create(&io_thread->thread, NULL, io_thread_procedure, &io_thread);
+    event_notifier_t *notifier = (io_thread->notifier = create_notifier());
+    ThreadQueue *queue = (io_thread->queue = create_tqueue(IO_QUEUE_SIZE, sizeof(IOOperation), alignof(IOOperation)));
+
+    if (notifier == NULL || queue == NULL || code == EAGAIN) {
+      if (notifier) destroy_notifier(notifier);
+      if (queue) free_tqueue(queue);
+    }
+
+    atomic_init(&io_thread->destroyed, false);
+    assert(pthread_detach(io_thread->thread) == 0);
+
+    succeed += 1;
   }
 
-  assert(pthread_detach(thread) == 0);
   return 0;
 }
 
-void destroy_io_thread() {
-  atomic_store_explicit(&destroyed, true, memory_order_relaxed);
-  signal_notifier(notifier, 1);
+void send_destroy_signal_to_io_threads() {
+  for (int64_t i = 0; i < io_thread_count; ++i) {
+    atomic_store_explicit(&io_threads[i].destroyed, true, memory_order_relaxed);
+    signal_notifier(io_threads[i].notifier, 1);
+  }
 }
 
 void add_io_request(const enum IOOpType type, Client *client, string_t to_write) {
-  IOOperation op;
-  op.type = type;
-  op.client = client;
-
-  /**
-   * TODO
-   * transactions are handled by transaction loop/thread, so IOOP_WRITE requests added by this loop.
-   * this loop outs responses to client.write_buf generally, then saves this write_buf to to_write string.
-   * After that, this method will be executed. There is a problem, if two transactions from same client will be handled:
-   *
-   * tx 1 => writes "A" to write_buf, then adds it to I/O requests
-   * tx 2 => writes "B" to write_buf, then adds it to I/O requests
-   *
-   * but, write_buf is only one buffer, so I/O requests from tx 1 and tx 2 consists of "B", not "A"
-   * if handling I/O requests is started, there will be collision.
-   */
-  op.to_write = RESP_OK_MESSAGE("PONG");
-
-  push_tqueue(queue, &op);
-  signal_notifier(notifier, 1);
+  // TODO
 }
 
 void *io_thread(void *arg) {
-  const sigset_t *set = (sigset_t *) arg;
-  assert(pthread_sigmask(SIG_BLOCK, set, NULL) == 0);
-  free(arg);
+  assert(pthread_sigmask(SIG_BLOCK, &set, NULL) == 0);
 
+  IOThread *thread = (IOThread *) arg;
   int added = -1, efd = -1;
 
   efd = CREATE_EVENTFD();
   if (efd == -1) goto DESTROY;
 
-  const int fd = get_notifier(notifier);
+  const int fd = get_notifier(thread->notifier);
 
   event_t event;
   CREATE_EVENT(event, fd);
@@ -104,13 +88,13 @@ void *io_thread(void *arg) {
 
   while (true) {
     WAIT_EVENTS(efd, events, 1, -1);
-    if (atomic_load_explicit(&destroyed, memory_order_relaxed)) break;
+    if (atomic_load_explicit(&thread->destroyed, memory_order_relaxed)) break;
 
-    const uint64_t count = consume_notifier(notifier);
+    const uint64_t count = consume_notifier(thread->notifier);
 
     for (uint64_t i = 0; i < count; ++i) {
       IOOperation op;
-      if (!pop_tqueue(queue, &op)) break;
+      if (!pop_tqueue(thread->queue, &op)) break;
 
       Client *client = op.client;
       if (client->id == -1) continue;
@@ -139,8 +123,8 @@ DESTROY:
   }
 
   if (efd != -1) close(efd);
-  destroy_notifier(notifier);
-  free_tqueue(queue);
+  destroy_notifier(thread->notifier);
+  free_tqueue(thread->queue);
   free_read_buffers();
 
   return NULL;

--- a/src/server/io.c
+++ b/src/server/io.c
@@ -1,6 +1,3 @@
-#include "server/io.h"
-#include <stdatomic.h>
-#include <stdint.h>
 #include <telly.h>
 
 #define IO_QUEUE_SIZE 512
@@ -79,6 +76,8 @@ void send_destroy_signal_to_io_threads() {
 }
 
 void add_io_request(const enum IOOpType type, Client *client, string_t to_write) {
+  if (client->id == -1) return;
+
   IOThread *selected = &io_threads[client->id % io_thread_count];
 
   IOOperation op = {

--- a/src/server/io.c
+++ b/src/server/io.c
@@ -1,3 +1,6 @@
+#include "server/io.h"
+#include <stdatomic.h>
+#include <stdint.h>
 #include <telly.h>
 
 #define IO_QUEUE_SIZE 512
@@ -47,7 +50,7 @@ int create_io_threads() {
       break;
     }
 
-    atomic_init(&io_thread->destroyed, false);
+    atomic_init(&io_thread->status, IO_THREAD_ACTIVE);
 
     const int code = pthread_create(&io_thread->thread, NULL, io_thread_procedure, io_thread);
     if (code == EAGAIN) goto CLEANUP_THREAD;
@@ -61,9 +64,18 @@ int create_io_threads() {
 
 void send_destroy_signal_to_io_threads() {
   for (int64_t i = 0; i < io_thread_count; ++i) {
-    atomic_store_explicit(&io_threads[i].destroyed, true, memory_order_relaxed);
+    atomic_store_explicit(&io_threads[i].status, IO_THREAD_PENDING_DESTROY, memory_order_relaxed);
     signal_notifier(io_threads[i].notifier, 1);
   }
+
+  WAIT_DESTROYED:
+  usleep(10);
+  for (int64_t i = 0; i < io_thread_count; ++i) {
+    if (atomic_load_explicit(&io_threads[i].status, memory_order_relaxed) != IO_THREAD_DESTROYED)
+      goto WAIT_DESTROYED;
+  }
+
+  free(io_threads);
 }
 
 void add_io_request(const enum IOOpType type, Client *client, string_t to_write) {
@@ -101,7 +113,7 @@ void *io_thread_procedure(void *arg) {
 
   while (true) {
     WAIT_EVENTS(efd, events, 1, -1);
-    if (atomic_load_explicit(&thread->destroyed, memory_order_relaxed)) break;
+    if (atomic_load_explicit(&thread->status, memory_order_relaxed) == IO_THREAD_PENDING_DESTROY) break;
 
     const uint64_t count = consume_notifier(thread->notifier);
 
@@ -143,5 +155,6 @@ DESTROY:
   arena_destroy(thread->resp_arena);
   arena_destroy(thread->ucmd_arena);
 
+  atomic_store_explicit(&thread->status, IO_THREAD_DESTROYED, memory_order_relaxed);
   return NULL;
 }

--- a/src/server/read_command.c
+++ b/src/server/read_command.c
@@ -70,6 +70,8 @@ void read_command(IOThread *thread, Client *client) {
 
     const struct CommandIndex *command_index = get_command_index(data.name->value, data.name->len);
 
+    // TODO: related to issue #44
+    // takes invalid command data because of that, then throws unknown command error
     if (!command_index) {
       unknown_command(client, data.name, thread->ucmd_arena);
       continue;

--- a/src/server/read_command.c
+++ b/src/server/read_command.c
@@ -2,38 +2,8 @@
 
 #define INITIAL_UNKNOWN_COMMAND_ARENA_SIZE 8192
 
-static char *buf = NULL;
-static Arena *arena = NULL;
-static Arena *ucmd_arena = NULL;
-
-int initialize_read_buffers() {
-  buf = malloc(RESP_BUF_SIZE);
-  if (buf == NULL) return -1;
-
-  arena = arena_create(INITIAL_RESP_ARENA_SIZE);
-  if (arena == NULL) {
-    free(buf);
-    return -1;
-  }
-
-  ucmd_arena = arena_create(INITIAL_UNKNOWN_COMMAND_ARENA_SIZE);
-  if (ucmd_arena == NULL) {
-    arena_destroy(arena);
-    free(buf);
-    return -1;
-  }
-
-  return 1;
-}
-
-void free_read_buffers() {
-  if (buf) free(buf);
-  if (arena) arena_destroy(arena);
-  if (ucmd_arena) arena_destroy(ucmd_arena);
-}
-
-static inline void unknown_command(Client *client, string_t *name) {
-  char *ubuf = arena_alloc(ucmd_arena, name->len + 22);
+static inline void unknown_command(Client *client, string_t *name, Arena *arena) {
+  char *ubuf = arena_alloc(arena, name->len + 22);
   const size_t nbytes = sprintf(ubuf, "-Unknown command '%s'\r\n", name->value);
 
   add_io_request(IOOP_WRITE, client, CREATE_STRING(ubuf, nbytes));
@@ -70,8 +40,8 @@ static inline void get_used_command(const commanddata_t *data, UsedCommand *comm
   atomic_store_explicit(&command->subcommand, subcommand, memory_order_relaxed);
 }
 
-void read_command(Client *client) {
-  int size = read_from_socket(client, buf, RESP_BUF_SIZE);
+void read_command(IOThread *thread, Client *client) {
+  int size = read_from_socket(client, thread->buf, RESP_BUF_SIZE);
 
   if (size == 0) {
     add_io_request(IOOP_TERMINATE, client, EMPTY_STRING());
@@ -82,13 +52,13 @@ void read_command(Client *client) {
 
   while (size != -1) {
     commanddata_t data;
-    if (!get_command_data(arena, client, buf, &at, &size, &data)) continue;
+    if (!get_command_data(thread->resp_arena, client, thread->buf, &at, &size, &data)) continue;
 
     if (size == at) {
       if (size != RESP_BUF_SIZE) {
         size = -1;
       } else {
-        size = read_from_socket(client, buf, RESP_BUF_SIZE);
+        size = read_from_socket(client, thread->buf, RESP_BUF_SIZE);
         at = 0;
       }
     }
@@ -101,7 +71,7 @@ void read_command(Client *client) {
     const struct CommandIndex *command_index = get_command_index(data.name->value, data.name->len);
 
     if (!command_index) {
-      unknown_command(client, data.name);
+      unknown_command(client, data.name, thread->ucmd_arena);
       continue;
     }
 

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -206,9 +206,6 @@ void start_server(Config *config) {
   server->eventfd = CREATE_EVENTFD();
   CLEANUP_RETURN_LOG_IF(server->eventfd == -1, "Cannot create epoll instance.");
 
-  server->io_eventfd = CREATE_EVENTFD();
-  CLEANUP_RETURN_LOG_IF(server->io_eventfd == -1, "Cannot create epoll instance.");
-
   event_t event;
   CREATE_EVENT(event, server->sockfd);
   CLEANUP_RETURN_LOG_IF(ADD_EVENT(server->eventfd, server->sockfd, event) == -1, "Cannot create epoll instance.");

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -50,7 +50,7 @@ static inline void cleanup() {
   destroy_transaction_thread();
   usleep(15);
 
-  destroy_io_thread();
+  send_destroy_signal_to_io_threads();
   usleep(15);
 
   free_transaction_blocks();
@@ -212,7 +212,7 @@ void start_server(Config *config) {
 
   CLEANUP_RETURN_IF(initialize_clients() == -1);
 
-  CLEANUP_RETURN_LOG_IF(create_io_thread() == -1, "Cannot create I/O thread.");
+  CLEANUP_RETURN_LOG_IF(create_io_threads() == -1, "Cannot create I/O thread.");
   write_log(LOG_INFO, "Created I/O thread.");
 
   server->start_at = time(NULL);

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -206,6 +206,9 @@ void start_server(Config *config) {
   server->eventfd = CREATE_EVENTFD();
   CLEANUP_RETURN_LOG_IF(server->eventfd == -1, "Cannot create epoll instance.");
 
+  server->io_eventfd = CREATE_EVENTFD();
+  CLEANUP_RETURN_LOG_IF(server->io_eventfd == -1, "Cannot create epoll instance.");
+
   event_t event;
   CREATE_EVENT(event, server->sockfd);
   CLEANUP_RETURN_LOG_IF(ADD_EVENT(server->eventfd, server->sockfd, event) == -1, "Cannot create epoll instance.");

--- a/src/transactions/thread.c
+++ b/src/transactions/thread.c
@@ -78,9 +78,21 @@ void *transaction_thread(void *arg) {
     TransactionBlock *block;
     uint64_t count = consume_notifier(tx_notifier);
 
-    while (count-- && pop_tqueue(tx_queue, &block)) { // TODO: unknown valgrind warning
+    // possible TODO: unknown valgrind warning
+    while (count > 0) {
+      if (atomic_load_explicit(&kill_pending, memory_order_relaxed)) {
+        // If there is no unfinished transaction, continue checking for kill_pending thread
+        if (!pop_tqueue(tx_queue, &block)) {
+          count--;
+          continue;
+        }
+      } else {
+        while (!pop_tqueue(tx_queue, &block)) cpu_relax();
+      }
+
       execute_transaction_block(block);
       remove_transaction_block(block);
+      count--;
     }
   }
 


### PR DESCRIPTION
Threads will be in the projects are listed as:
### Main thread
Responsibilities of this thread is listed as:
* Executing `epoll_wait()/kqueue()` to take server events such as client accepting, client termination, availability for reading
* Adding these events to I/O operation queue
* Waiting until to end of executing added I/O operations, **this procedure will be handled as adding all of them, then waits all of them; not individually**. That waiting is required for a barrier for `epoll_wait()/kqueue()`.

Events will be collected by kernel buffer because of this barrier. So, system call cost of `epoll_wait()/kqueue()`, redundant jumps and cpu time will be reduced.

**`Waiting operations and barrier could not implemented in this PR`**

### Transaction thread
Responsibilities of this thread is listed as:
* Executing each command from pipelined or individual sending
* Adding writing events to I/O operation queue

### I/O threads
Each I/O thread is responsible for a few clients, clients will not be distributed between them. Handling client #X is planned to be in IO Thread #Y if even client has not connected yet.

Responsibilities of these threads is listed as:
* Executing I/O operations

## Unplanned things
They are unplanned, but completed via this pull request.

* Fixed disappearing transactions https://github.com/aloima/tellydb/pull/43/commits/8cd1d3b7eb4d84b6a985a6b18cec00bcab9e7f51