### PR TITLE
refactor(database): centralize error handling on save_data()

### DIFF
--- a/src/database/file.c
+++ b/src/database/file.c
@@ -320,16 +320,52 @@ static inline void generate_headers(char *headers, const uint32_t server_age) {
   memcpy(headers + 2, &server_age, sizeof(uint32_t));
 }
 
-// TODO: better error handling
-// TODO: maybe mmap() will be used for directly saving instead of parsing all data individually
+static inline void log_save_io_error(const char *what) {
+  switch (errno) {
+    case EIO:
+      write_log(LOG_ERR, "%s: I/O error.", what);
+      break;
+    case ENOSPC:
+      write_log(LOG_ERR, "%s: no space left on device.", what);
+      break;
+    case EDQUOT:
+      write_log(LOG_ERR, "%s: disk quota exceeded.", what);
+      break;
+    case EFBIG:
+      write_log(LOG_ERR, "%s: file size limit exceeded.", what);
+      break;
+    case EBADF:
+      write_log(LOG_ERR, "%s: bad file descriptor.", what);
+      break;
+    case EINTR:
+      write_log(LOG_ERR, "%s: interrupted by signal.", what);
+      break;
+    default:
+      write_log(LOG_ERR, "%s: errno %d.", what, errno);
+      break;
+  }
+}
+
 int save_data(const uint32_t server_age) {
   if (saving) return -1;
-
   saving = true;
-  lseek(fd, 0, SEEK_SET);
 
-  char *block;
-  if (posix_memalign((void **) &block, block_size, block_size) != 0) return -1;
+  char *block = NULL;
+  char *data = NULL;
+  bool io_failed = false;
+  int ret = -1;
+
+  if (lseek(fd, 0, SEEK_SET) == (off_t) -1) {
+    log_save_io_error("Cannot seek to start of database file");
+    io_failed = true;
+    goto cleanup;
+  }
+
+  if (posix_memalign((void **) &block, block_size, block_size) != 0) {
+    write_log(LOG_ERR, "Cannot allocate aligned memory for database block, out of memory.");
+    block = NULL; // posix_memalign leaves *memptr undefined on failure
+    goto cleanup;
+  }
 
   memset(block, 0, block_size);
 
@@ -360,11 +396,9 @@ int save_data(const uint32_t server_age) {
         memcpy(block + length, password->data, allowed);
 
         if (write(fd, block, block_size) == -1) {
-          saving = false;
-          free(block);
-          close_database_fd();
-          write_log(LOG_ERR, "The passwords cannot be written to database file, it is a OS-specific error.");
-          return -1;
+          log_save_io_error("Cannot write passwords block to database file");
+          io_failed = true;
+          goto cleanup;
         }
 
         const uint32_t remaining = (48 - allowed); // remaining byte count except permissions
@@ -409,8 +443,11 @@ int save_data(const uint32_t server_age) {
         continue;
       }
 
-      char *data = malloc(data_size);
-      if (!data) return -1;
+      data = malloc(data_size);
+      if (!data) {
+        write_log(LOG_ERR, "Cannot allocate buffer for KV data while saving, out of memory.");
+        goto cleanup;
+      }
 
       for (uint32_t i = 0; i < capacity; ++i) {
         struct KVPair *kv = database->data[i];
@@ -426,12 +463,9 @@ int save_data(const uint32_t server_age) {
           memcpy(block + length, data, complete);
 
           if (write(fd, block, block_size) == -1) {
-            saving = false;
-            free(data);
-            free(block);
-            close_database_fd();
-            write_log(LOG_ERR, "The data cannot be written to database file, it is a OS-specific error.");
-            return -1;
+            log_save_io_error("Cannot write KV block to database file");
+            io_failed = true;
+            goto cleanup;
           }
 
           remaining -= complete;
@@ -441,12 +475,9 @@ int save_data(const uint32_t server_age) {
               memcpy(block, data + (kv_size - remaining), block_size);
 
               if (write(fd, block, block_size) == -1) {
-                saving = false;
-                free(data);
-                free(block);
-                close_database_fd();
-                write_log(LOG_ERR, "The data cannot be written to database file, it is a OS-specific error.");
-                return -1;
+                log_save_io_error("Cannot write KV continuation block to database file");
+                io_failed = true;
+                goto cleanup;
               }
 
               remaining -= block_size;
@@ -464,32 +495,33 @@ int save_data(const uint32_t server_age) {
       }
 
       free(data);
+      data = NULL;
       node = node->next;
     }
   }
 
   if (length != block_size) {
     if (write(fd, block, block_size) == -1) {
-      saving = false;
-      free(block);
-      close_database_fd();
-      write_log(LOG_ERR, "The data cannot be written to database file, it is a OS-specific error.");
-      return -1;
+      log_save_io_error("Cannot write final block to database file");
+      io_failed = true;
+      goto cleanup;
     }
   }
 
   if (ftruncate(fd, total) == -1) {
-    saving = false;
-    free(block);
-    close_database_fd();
-    write_log(LOG_ERR, "The data cannot be written to database file, it is a OS-specific error.");
-    return -1;
+    log_save_io_error("Cannot truncate database file to actual data size");
+    io_failed = true;
+    goto cleanup;
   }
 
-  free(block);
+  ret = 0;
 
+cleanup:
+  free(data);
+  free(block);
   saving = false;
-  return 0;
+  if (io_failed) close_database_fd();
+  return ret;
 }
 
 void *save_thread(void *arg) {

--- a/src/database/file.c
+++ b/src/database/file.c
@@ -355,11 +355,7 @@ int save_data(const uint32_t server_age) {
   bool io_failed = false;
   int ret = -1;
 
-  if (lseek(fd, 0, SEEK_SET) == (off_t) -1) {
-    log_save_io_error("Cannot seek to start of database file");
-    io_failed = true;
-    goto cleanup;
-  }
+  ASSERT(lseek(fd, 0, SEEK_SET), !=, -1);
 
   if (posix_memalign((void **) &block, block_size, block_size) != 0) {
     write_log(LOG_ERR, "Cannot allocate aligned memory for database block, out of memory.");

--- a/src/database/file.c
+++ b/src/database/file.c
@@ -517,8 +517,8 @@ int save_data(const uint32_t server_age) {
   ret = 0;
 
 cleanup:
-  free(data);
-  free(block);
+  if (data) free(data);
+  if (block) free(block);
   saving = false;
   if (io_failed) close_database_fd();
   return ret;


### PR DESCRIPTION
  - Replace 5 duplicated cleanup blocks with a single goto cleanup path
  - Add log_save_io_error() helper mapping errno (EIO, ENOSPC, EDQUOT, EFBIG, EBADF, EINTR) to specific messages; fallback prints errno

  Fixes the following silent-failure bugs:
  - posix_memalign() failure left saving=true and wrote no log, permanently disabling further saves
  - lseek() return value was unchecked
  - malloc() failure for the per-database KV buffer leaked the aligned block and left saving=true

  Preserves existing semantics: close_database_fd() is called only on
  I/O failures (lseek, write, ftruncate), not on allocation failures.